### PR TITLE
refactor 3dt router, add report download

### DIFF
--- a/3dt.go
+++ b/3dt.go
@@ -1,16 +1,15 @@
 package main
 
 import (
-
 	"fmt"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/mesosphere/3dt/api"
+	"github.com/dcos/3dt/api"
 	"net/http"
 )
 
-const	Version string = "0.0.9"
+const Version string = "0.0.9"
 
 func GetVersion() string {
 	return (fmt.Sprintf("Version: %s", Version))

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -1,7 +1,7 @@
 package api_test
 
 import (
-	. "github.com/mesosphere/3dt/api"
+	. "github.com/dcos/3dt/api"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -11,9 +11,8 @@ import (
 // FakeSystemdType success
 type FakeSystemdType struct {
 	newCalled bool
-	params 	map[string]bool
-	units []string
-	Aaa string
+	params    map[string]bool
+	units     []string
 }
 
 func (st *FakeSystemdType) GetHostname() string {
@@ -100,12 +99,11 @@ var _ = Describe("Test systemd", func() {
 					},
 				},
 				DcosVersion: "",
-				Hostname: "MyHostName",
-				IpAddress: "127.0.0.1",
-				Role: "master",
-				MesosId: "node-id-123",
-				TdtVersion: "0.0.7",
-
+				Hostname:    "MyHostName",
+				IpAddress:   "127.0.0.1",
+				Role:        "master",
+				MesosId:     "node-id-123",
+				TdtVersion:  "0.0.7",
 			}))
 			Expect(cfg.SystemdUnits).Should(Equal([]string{
 				"dcos-setup.service",

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -1,7 +1,7 @@
 package api_test
 
 import (
-	. "github.com/mesosphere/3dt/api"
+	. "github.com/dcos/3dt/api"
 
 	"fmt"
 	"time"

--- a/api/router.go
+++ b/api/router.go
@@ -9,26 +9,109 @@ import (
 
 const BaseRoute string = "/system/health/v1"
 
+type routeHandler struct {
+	url 	string
+	handler func(http.ResponseWriter, *http.Request)
+	headers []header
+}
+
+type header struct {
+	name	string
+	value	string
+}
+
+func headerMiddleware(next http.Handler, headers []header) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultHeaders := []header{
+			{
+				name: "Content-type",
+				value: "application/json",
+			},
+		}
+		for _, header := range(append(defaultHeaders, headers...)) {
+			w.Header().Add(header.name, header.value)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func getRoutes(config *Config) []routeHandler {
+	return []routeHandler{
+		{
+			// /system/health/v1
+			url: BaseRoute,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				UnitsHealthStatus(w, r, config)
+			},
+		},
+		{
+			// /system/health/v1/report
+			url: fmt.Sprintf("%s/report", BaseRoute),
+			handler: ReportHandler,
+		},
+		{
+			// /system/health/v1/report/download
+			url: fmt.Sprintf("%s/report/download", BaseRoute),
+			handler: ReportHandler,
+			headers: []header{
+				{
+					name: "Content-disposition",
+					value: "attachment; filename=health-report.json",
+				},
+			},
+		},
+		{
+			// /system/health/v1/units
+			url: fmt.Sprintf("%s/units", BaseRoute),
+			handler: GetAllUnitsHandler,
+		},
+		{
+			// /system/health/v1/units/<unitid>
+			url: fmt.Sprintf("%s/units/{unitid}", BaseRoute),
+			handler: GetUnitByIdHandler,
+		},
+		{
+			// /system/health/v1/units/<unitid>/nodes
+			url: fmt.Sprintf("%s/units/{unitid}/nodes", BaseRoute),
+			handler: GetNodesByUnitIdHandler,
+		},
+		{
+			// /system/health/v1/units/<unitid>/nodes/<nodeid>
+			url: fmt.Sprintf("%s/units/{unitid}/nodes/{nodeid}", BaseRoute),
+			handler: GetNodeByUnitIdNodeIdHandler,
+		},
+		{
+			// /system/health/v1/nodes
+			url: fmt.Sprintf("%s/nodes", BaseRoute),
+			handler: GetNodesHandler,
+		},
+		{
+			// /system/health/v1/nodes/<nodeid>
+			url: fmt.Sprintf("%s/nodes/{nodeid}", BaseRoute),
+			handler: GetNodeByIdHandler,
+		},
+		{
+			// /system/health/v1/nodes/<nodeid>/units
+			url:fmt.Sprintf("%s/nodes/{nodeid}/units", BaseRoute),
+			handler: GetNodeUnitsByNodeIdHandler,
+		},
+		{
+			// /system/health/v1/nodes/<nodeid>/units/<unitid>
+			url: fmt.Sprintf("%s/nodes/{nodeid}/units/{unitid}", BaseRoute),
+			handler: GetNodeUnitByNodeIdUnitIdHandler,
+		},
+	}
+}
+
+func loadRoutes(router *mux.Router, config *Config) *mux.Router {
+	for _, route := range getRoutes(config) {
+		handler := http.HandlerFunc(route.handler)
+		router.Handle(route.url, headerMiddleware(handler, route.headers)).Methods("GET")
+	}
+	return router
+}
+
 func NewRouter(config *Config) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	// pass config structure to a handler
-	router.HandleFunc(BaseRoute, func(w http.ResponseWriter, r *http.Request) {
-		UnitsHealthStatus(w, r, config)
-	}).Methods("GET")
-
-	// local list of systemd units
-	router.HandleFunc(fmt.Sprintf("%s/report", BaseRoute), ReportHandler).Methods("GET")
-
-	// collected list of units
-	router.HandleFunc(fmt.Sprintf("%s/units", BaseRoute), GetAllUnitsHandler).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("%s/units/{unitid}", BaseRoute), GetUnitByIdHandler).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("%s/units/{unitid}/nodes", BaseRoute), GetNodesByUnitIdHandler).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("%s/units/{unitid}/nodes/{nodeid}", BaseRoute), GetNodeByUnitIdNodeIdHandler).Methods("GET")
-
-	// collected list of nodes
-	router.HandleFunc(fmt.Sprintf("%s/nodes", BaseRoute), GetNodesHandler).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("%s/nodes/{nodeid}", BaseRoute), GetNodeByIdHandler).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("%s/nodes/{nodeid}/units", BaseRoute), GetNodeUnitsByNodeIdHandler).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("%s/nodes/{nodeid}/units/{unitid}", BaseRoute), GetNodeUnitByNodeIdUnitIdHandler).Methods("GET")
-	return router
+	return loadRoutes(router, config)
 }


### PR DESCRIPTION
- use middleware to make all endpoints to return
  Content-Type: application/json
- add new endpoint /system/health/v1/report/download
  which uses the same handler as report but adds a new header
  Content-disposition: attachment; filename=health-report.json
