### PR TITLE
add history service support

### DIFF
--- a/3dt.go
+++ b/3dt.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 )
 
-
 func getVersion() string {
 	return (fmt.Sprintf("Version: %s, Revision: %s", api.Version, api.Revision))
 }

--- a/api/config.go
+++ b/api/config.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-const Version string = "0.0.12"
+const Version string = "0.0.13"
 
 var Revision string
 

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -497,7 +497,7 @@ func (s *HandlersTestSuit) TestStartUpdateHealthReportFunc() {
 		DcosVersion: "",
 		Role:        "master",
 		MesosId:     "node-id-123",
-		TdtVersion:  "0.0.12",
+		TdtVersion:  "0.0.13",
 	})
 }
 

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -51,3 +51,9 @@ type SystemdInterface interface {
 	// Get mesos node id, first argument is a role, second argument is a json field name
 	GetMesosNodeId(string, string) string
 }
+
+// interface defines where to get a list of mesos agent
+type agentResponder interface {
+	getAgentSource() ([]string, error)
+	getMesosAgents([]string) ([]Node, error)
+}

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -145,6 +145,49 @@ func (s *PullerTestSuit) TestPullerNotFindUnit() {
 	s.assert.Equal(unit, UnitResponseFieldsStruct{})
 }
 
+func (s *PullerTestSuit) TestdnsRespondergetAgentSource() {
+	dns := dnsResponder{
+		defaultMasterAddress: "leader-non-existed.mesos",
+	}
+	ips, err := dns.getAgentSource()
+	s.assert.Empty(ips)
+	s.assert.NotEmpty(err)
+
+	dns2 := dnsResponder{
+		defaultMasterAddress: "dcos.io",
+	}
+	ips2, err := dns2.getAgentSource()
+	s.assert.NotEmpty(ips2)
+	s.assert.Empty(err)
+}
+
+func (s *PullerTestSuit) TestdnsRespondergetMesosAgents() {
+	dns := dnsResponder{
+		defaultMasterAddress: "leader-non-existed.mesos",
+	}
+	nodes, err := dns.getMesosAgents([]string{"127.0.0.1"})
+	s.assert.Empty(nodes)
+	s.assert.NotEmpty(err)
+}
+
+func (s *PullerTestSuit) TesthistoryServiceRespondergetAgentSource() {
+	h := historyServiceResponder{
+		defaultPastTime: "/hour/",
+	}
+	files, err := h.getAgentSource()
+	s.assert.Empty(files)
+	s.assert.NotEmpty(err)
+}
+
+func (s *PullerTestSuit) TesthistoryServiceRespondergetMesosAgents() {
+	h := historyServiceResponder{
+		defaultPastTime: "/hour/",
+	}
+	nodes, err := h.getMesosAgents([]string{"/tmp/test.json"})
+	s.assert.Empty(nodes)
+	s.assert.NotEmpty(err)
+}
+
 func TestPullerTestSuit(t *testing.T) {
 	suite.Run(t, new(PullerTestSuit))
 }


### PR DESCRIPTION
a list of agent nodes are coming from leader.mesos endpoint. If the endpoint
is not available, we can stil get a list of nodes from a hisotry service.
Scan all json dumps for the past hour, find unique agent nodes and use them.