### PR TITLE
3dt as system logs collector [WIP]

### DIFF
--- a/3dt.go
+++ b/3dt.go
@@ -13,9 +13,9 @@ func getVersion() string {
 	return (fmt.Sprintf("Version: %s, Revision: %s", api.Version, api.Revision))
 }
 
-func runDiag(config api.Config) int {
+func runDiag(dt api.Dt) int {
 	var exitCode int = 0
-	units, err := api.GetUnitsProperties(&config)
+	units, err := api.GetUnitsProperties(dt.Cfg, dt.DtHealth)
 	if err != nil {
 		log.Error(err)
 		return 1
@@ -39,6 +39,15 @@ func main() {
 		log.Error(err)
 		os.Exit(1)
 	}
+
+	// init 3dt dependencies
+	dt := api.Dt{
+		DtPuller: &api.PullType{},
+		DtHealth: &api.DcosHealth{},
+		DtSnapshotJob: &api.SnapshotJob{},
+		Cfg: &config,
+	}
+
 	// print version and exit
 	if config.FlagVersion {
 		fmt.Println(getVersion())
@@ -47,7 +56,7 @@ func main() {
 
 	// run local diagnostics, verify all systemd units are healthy.
 	if config.FlagDiag {
-		os.Exit(runDiag(config))
+		os.Exit(runDiag(dt))
 	}
 
 	// set verbose (debug) output.
@@ -57,14 +66,13 @@ func main() {
 
 	// start pulling every 60 seconds.
 	if config.FlagPull {
-		puller := api.PullType{}
-		go api.StartPullWithInterval(config, &puller, readyChan)
+		go api.StartPullWithInterval(dt, readyChan)
 	}
 
 	// start diagnostic server and expose endpoints.
 	log.Info("Start 3DT")
-	go api.StartUpdateHealthReport(config, readyChan, false)
-	router := api.NewRouter(&config)
+	go api.StartUpdateHealthReport(dt.Cfg, dt.DtHealth, readyChan, false)
+	router := api.NewRouter(dt)
 	log.Infof("Exposing 3DT API on 0.0.0.0:%d", config.FlagPort)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.FlagPort), router))
 }

--- a/3dt.go
+++ b/3dt.go
@@ -46,6 +46,7 @@ func main() {
 		DtHealth: &api.DcosHealth{},
 		DtSnapshotJob: &api.SnapshotJob{},
 		Cfg: &config,
+		HTTPRequest: &api.HTTPRequest{},
 	}
 
 	// print version and exit

--- a/api/config.go
+++ b/api/config.go
@@ -16,33 +16,40 @@ var Revision string
 type Config struct {
 	Version                         string
 	Revision                        string
-	MesosIpDiscoveryCommand         string
-	DcosVersion                     string
-	SystemdUnits                    []string
+	MesosIpDiscoveryCommand                   string
+	DcosVersion                               string
+	SystemdUnits                              []string
 
-	FlagPull                        bool
-	FlagDiag                        bool
-	FlagVerbose                     bool
-	FlagVersion                     bool
-	FlagPort                        int
-	FlagPullInterval                int
-	FlagSnapshotDir                 string
-	FlagSnapshotEndpointsConfigFile string
-	FlagSnapshotUnitsLogsSinceHours string
-	FlagSnapshotTimeoutMinutes      int
+	FlagPull                                  bool
+	FlagDiag                                  bool
+	FlagVerbose                               bool
+	FlagVersion                               bool
+	FlagPort                                  int
+	FlagPullInterval                          int
+	FlagSnapshotDir                           string
+	FlagSnapshotEndpointsConfigFile           string
+	FlagSnapshotUnitsLogsSinceHours           string
+	FlagSnapshotJobTimeoutMinutes             int
+	FlagSnapshotJobGetSingleUrlTimeoutMinutes int
+	FlagCommandExecTimeoutSec                 int
 }
 
 func (c *Config) SetFlags(fs *flag.FlagSet) {
-	fs.BoolVar(&c.FlagPull, "pull", c.FlagPull, "Try to pull checks from DC/OS hosts.")
-	fs.BoolVar(&c.FlagDiag, "diag", c.FlagDiag, "Get diagnostics output once on the CLI. Does not expose API.")
-	fs.BoolVar(&c.FlagVerbose, "verbose", c.FlagVerbose, "Use verbose debug output.")
-	fs.BoolVar(&c.FlagVersion, "version", c.FlagVersion, "Print version.")
-	fs.IntVar(&c.FlagPort, "port", c.FlagPort, "Web server TCP port.")
-	fs.IntVar(&c.FlagPullInterval, "pull-interval", c.FlagPullInterval, "Set pull interval, default 60 sec.")
-	fs.StringVar(&c.FlagSnapshotDir, "snapshot-dir", c.FlagSnapshotDir, "Set a path to store snapshots.")
-	fs.StringVar(&c.FlagSnapshotEndpointsConfigFile, "endpoint-config", c.FlagSnapshotEndpointsConfigFile, "Use endpoints_config.yaml")
+	fs.BoolVar(&c.FlagPull, "pull", c.FlagPull, "Try to pull checks from DC/OS hosts")
+	fs.BoolVar(&c.FlagDiag, "diag", c.FlagDiag, "Get diagnostics output once on the CLI. Does not expose API")
+	fs.BoolVar(&c.FlagVerbose, "verbose", c.FlagVerbose, "Use verbose debug output")
+	fs.BoolVar(&c.FlagVersion, "version", c.FlagVersion, "Print version")
+	fs.IntVar(&c.FlagPort, "port", c.FlagPort, "Web server TCP port")
+	fs.IntVar(&c.FlagPullInterval, "pull-interval", c.FlagPullInterval, "Set pull interval")
+	fs.StringVar(&c.FlagSnapshotDir, "snapshot-dir", c.FlagSnapshotDir, "Set a path to store snapshots")
+	fs.StringVar(&c.FlagSnapshotEndpointsConfigFile, "endpoint-config", c.FlagSnapshotEndpointsConfigFile, "Use endpoints_config.json")
 	fs.StringVar(&c.FlagSnapshotUnitsLogsSinceHours, "snapshot-units-since", c.FlagSnapshotUnitsLogsSinceHours, "Collect systemd units logs since")
-	fs.IntVar(&c.FlagSnapshotTimeoutMinutes, "snapshot-timeout", c.FlagSnapshotTimeoutMinutes, "Set a timeout to collect logs from each node in a cluster, default 10 min.")
+	fs.IntVar(&c.FlagSnapshotJobTimeoutMinutes, "snapshot-job-timeout", c.FlagSnapshotJobTimeoutMinutes,
+		"Set a global snapshot job timeout")
+	fs.IntVar(&c.FlagSnapshotJobGetSingleUrlTimeoutMinutes, "snapshot-url-timeout", c.FlagSnapshotJobGetSingleUrlTimeoutMinutes,
+		"Set a local timeout for every single GET request to a log endpoint")
+	fs.IntVar(&c.FlagCommandExecTimeoutSec, "command-exec-timeout", c.FlagCommandExecTimeoutSec,
+		"Set command executing timeout")
 }
 
 func LoadDefaultConfig(args []string) (config Config, err error) {
@@ -59,7 +66,9 @@ func LoadDefaultConfig(args []string) (config Config, err error) {
 	config.Revision = Revision
 
 	config.FlagSnapshotDir = "/opt/mesosphere/snapshots"
-	config.FlagSnapshotTimeoutMinutes = 720 //12 hours
+	config.FlagSnapshotJobTimeoutMinutes = 720 //12 hours
+	config.FlagSnapshotJobGetSingleUrlTimeoutMinutes = 5
+	config.FlagCommandExecTimeoutSec = 10
 
 	config.FlagSnapshotEndpointsConfigFile = "/opt/mesosphere/endpoints_config.json"
 	config.FlagSnapshotUnitsLogsSinceHours = "24"

--- a/api/config.go
+++ b/api/config.go
@@ -8,25 +8,28 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-const Version string = "0.0.13"
+const Version string = "0.1.0"
 
 var Revision string
 
 // config structure used in main
 type Config struct {
-	Version                 string
-	Revision                string
-	MesosIpDiscoveryCommand string
-	DcosVersion             string
-	HealthReport            HealthReporter
-	SystemdUnits            []string
+	Version                         string
+	Revision                        string
+	MesosIpDiscoveryCommand         string
+	DcosVersion                     string
+	SystemdUnits                    []string
 
-	FlagPull         bool
-	FlagDiag         bool
-	FlagVerbose      bool
-	FlagVersion      bool
-	FlagPort         int
-	FlagPullInterval int
+	FlagPull                        bool
+	FlagDiag                        bool
+	FlagVerbose                     bool
+	FlagVersion                     bool
+	FlagPort                        int
+	FlagPullInterval                int
+	FlagSnapshotDir                 string
+	FlagSnapshotEndpointsConfigFile string
+	FlagSnapshotUnitsLogsSinceHours string
+	FlagSnapshotTimeoutMinutes      int
 }
 
 func (c *Config) SetFlags(fs *flag.FlagSet) {
@@ -36,6 +39,10 @@ func (c *Config) SetFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.FlagVersion, "version", c.FlagVersion, "Print version.")
 	fs.IntVar(&c.FlagPort, "port", c.FlagPort, "Web server TCP port.")
 	fs.IntVar(&c.FlagPullInterval, "pull-interval", c.FlagPullInterval, "Set pull interval, default 60 sec.")
+	fs.StringVar(&c.FlagSnapshotDir, "snapshot-dir", c.FlagSnapshotDir, "Set a path to store snapshots.")
+	fs.StringVar(&c.FlagSnapshotEndpointsConfigFile, "endpoint-config", c.FlagSnapshotEndpointsConfigFile, "Use endpoints_config.yaml")
+	fs.StringVar(&c.FlagSnapshotUnitsLogsSinceHours, "snapshot-units-since", c.FlagSnapshotUnitsLogsSinceHours, "Collect systemd units logs since")
+	fs.IntVar(&c.FlagSnapshotTimeoutMinutes, "snapshot-timeout", c.FlagSnapshotTimeoutMinutes, "Set a timeout to collect logs from each node in a cluster, default 10 min.")
 }
 
 func LoadDefaultConfig(args []string) (config Config, err error) {
@@ -51,6 +58,12 @@ func LoadDefaultConfig(args []string) (config Config, err error) {
 	config.Version = Version
 	config.Revision = Revision
 
+	config.FlagSnapshotDir = "/opt/mesosphere/snapshots"
+	config.FlagSnapshotTimeoutMinutes = 720 //12 hours
+
+	config.FlagSnapshotEndpointsConfigFile = "/opt/mesosphere/endpoints_config.json"
+	config.FlagSnapshotUnitsLogsSinceHours = "24"
+
 	detectIpCmd := os.Getenv("MESOS_IP_DISCOVERY_COMMAND")
 	if detectIpCmd == "" {
 		detectIpCmd = "/opt/mesosphere/bin/detect_ip"
@@ -62,9 +75,7 @@ func LoadDefaultConfig(args []string) (config Config, err error) {
 		log.Warning("Environment variable DCOS_VERSION is not set")
 	}
 	config.DcosVersion = os.Getenv("DCOS_VERSION")
-	config.HealthReport = &DcosHealth{}
 	config.SystemdUnits = []string{"dcos-setup.service", "dcos-link-env.service", "dcos-download.service"}
-
 	flagSet := flag.NewFlagSet("3dt", flag.ContinueOnError)
 	config.SetFlags(flagSet)
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -29,7 +29,7 @@ func writeResponse(w http.ResponseWriter, response snapshotReportResponse) {
 // If snapshot was found on a remote host the local node will send a POST request to remove the snapshot.
 func deleteSnapshotHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
 	vars := mux.Vars(r)
-	response, err := dt.DtSnapshotJob.delete(vars["file"], dt.Cfg, dt.DtPuller, dt.DtHealth)
+	response, err := dt.DtSnapshotJob.delete(vars["file"], dt.Cfg, dt.DtPuller, dt.DtHealth, dt.HTTPRequest)
 	if err != nil {
 		log.Error(err)
 	}
@@ -45,7 +45,7 @@ func statusSnapshotReporthandler(w http.ResponseWriter, r *http.Request, dt Dt) 
 
 // A handler function returns a map of master node ip address as a key and snapshotReportStatus as a value.
 func statusAllSnapshotReporthandler(w http.ResponseWriter, r *http.Request, dt Dt) {
-	status, err := dt.DtSnapshotJob.getStatusAll(dt.Cfg, dt.DtPuller)
+	status, err := dt.DtSnapshotJob.getStatusAll(dt.Cfg, dt.DtPuller, dt.HTTPRequest)
 	if err != nil {
 		response, _ := prepareResponseWithErr(http.StatusServiceUnavailable, err)
 		writeResponse(w, response)
@@ -59,7 +59,7 @@ func statusAllSnapshotReporthandler(w http.ResponseWriter, r *http.Request, dt D
 // A handler function cancels a job running on a local node first. If a job is running on a remote node
 // it will try to send a POST request to cancel it.
 func cancelSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
-	response, err := dt.DtSnapshotJob.cancel(dt.Cfg, dt.DtPuller, dt.DtHealth)
+	response, err := dt.DtSnapshotJob.cancel(dt.Cfg, dt.DtPuller, dt.DtHealth, dt.HTTPRequest)
 	if err != nil {
 		log.Error(err)
 	}
@@ -68,7 +68,7 @@ func cancelSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) 
 
 // A handler function returns a map of master ip as a key and a list of snapshots as a value.
 func listAvailableGLobalSnapshotFilesHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
-	allSnapshots, err := listAllSnapshots(dt.Cfg, dt.DtPuller)
+	allSnapshots, err := listAllSnapshots(dt.Cfg, dt.DtPuller, dt.HTTPRequest)
 	if err != nil {
 		response, _ := prepareResponseWithErr(http.StatusServiceUnavailable, err)
 		writeResponse(w, response)
@@ -111,7 +111,7 @@ func downloadSnapshotHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
 		return
 	}
 	// do a reverse proxy
-	node, location, ok, err := dt.DtSnapshotJob.isSnapshotAvailable(vars["file"], dt.Cfg, dt.DtPuller)
+	node, location, ok, err := dt.DtSnapshotJob.isSnapshotAvailable(vars["file"], dt.Cfg, dt.DtPuller, dt.HTTPRequest)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -145,7 +145,7 @@ func createSnapshotHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
 		writeResponse(w, response)
 		return
 	}
-	response, err := dt.DtSnapshotJob.run(req, dt.Cfg, dt.DtPuller, dt.DtHealth)
+	response, err := dt.DtSnapshotJob.run(req, dt.Cfg, dt.DtPuller, dt.DtHealth, dt.HTTPRequest)
 	if err != nil {
 		log.Error(err)
 	}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1,16 +1,224 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
+	"io"
 	"net/http"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
 )
 
 // Route handlers
+func deleteSnapshotHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	response := snapshotReportResponse{}
+	vars := mux.Vars(r)
+	host, _, ok, err := dt.DtSnapshotJob.isSnapshotAvailable(vars["file"], dt.Cfg, dt.DtPuller)
+	if err != nil {
+		response.Status = vars["file"] + " not found"
+		//writeResponse(&w, response, http.StatusNotFound)
+		return
+	}
+	if ok {
+		if host == fmt.Sprintf("%s:%d", dt.DtHealth.DetectIp(), dt.Cfg.FlagPort) {
+			log.Infof("Snapshot %s found on a localhost", vars["file"])
+			if err := dt.DtSnapshotJob.DeleteSnapshot(vars["file"], dt.Cfg); err != nil {
+				log.Error(err)
+				response.Status = err.Error()
+				//writeResponse(&w, response, http.StatusServiceUnavailable)
+				return
+			}
+			response.Status = vars["file"] + " has been sucesfully deleted"
+			//writeResponse(&w, response, http.StatusOK)
+			return
+		}
+		// found a snapshot on a remote host
+		url := fmt.Sprintf("http://%s%s/report/snapshot/delete/%s", host, BaseRoute, vars["file"])
+		log.Infof("POST %s", url)
+		req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte{}))
+		if err != nil {
+			log.Error(err)
+			response.Status = err.Error()
+			//writeResponse(&w, response, http.StatusServiceUnavailable)
+			return
+		}
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Error(err)
+			response.Status = err.Error()
+			//writeResponse(&w, response, http.StatusServiceUnavailable)
+			return
+		}
+		defer resp.Body.Close()
+		response.Status = "Removed napshot sucessfully " + vars["file"]
+		//writeResponse(&w, response, http.StatusServiceUnavailable)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func statusSnapshotReporthandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	if err := json.NewEncoder(w).Encode(dt.DtSnapshotJob.getStatus(dt.Cfg)); err != nil {
+		log.Error("Failed to encode responses to json")
+	}
+}
+
+func statusAllSnapshotReporthandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	status, err := dt.DtSnapshotJob.getStatusAll(dt.Cfg, dt.DtPuller)
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		log.Error("Failed to encode responses to json")
+	}
+}
+
+func cancelSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	response := snapshotReportResponse{}
+	if !dt.DtSnapshotJob.Running {
+		response.Status = "Unable to cancel, job is not running"
+		writeResponse(&w, response, http.StatusBadRequest)
+		return
+	}
+	if err := dt.DtSnapshotJob.cancel(dt.DtHealth); err != nil {
+		log.Error(err)
+		response.Status = "Cancel job failed"
+		writeResponse(&w, response, http.StatusServiceUnavailable)
+		return
+	}
+	response.Status = "Attempting to cancel the job, check status for more details"
+	writeResponse(&w, response, http.StatusOK)
+}
+
+func listAllSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	allSnapshots, err := listAllSnapshots(dt.Cfg, dt.DtPuller)
+	if err != nil {
+		log.Error(err)
+	}
+	if err := json.NewEncoder(w).Encode(allSnapshots); err != nil {
+		log.Error("Failed to encode responses to json")
+	}
+}
+
+func listSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	matches, err := dt.DtSnapshotJob.findLocalSnapshot(dt.Cfg)
+	if err != nil {
+		log.Error(err)
+		http.NotFound(w, r)
+		return
+	}
+
+	var snapshots []string
+	for _, file := range matches {
+		baseFile := filepath.Base(file)
+		snapshots = append(snapshots, fmt.Sprintf("%s/report/snapshot/serve/%s", BaseRoute, baseFile))
+	}
+	if err := json.NewEncoder(w).Encode(snapshots); err != nil {
+		log.Error("Failed to encode responses to json")
+	}
+}
+
+func downloadSnapshotHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	vars := mux.Vars(r)
+	serveFile := dt.Cfg.FlagSnapshotDir + "/" + vars["file"]
+	_, err := os.Stat(serveFile)
+	if err == nil {
+		w.Header().Add("Content-disposition", fmt.Sprintf("attachment; filename=%s", vars["file"]))
+		http.ServeFile(w, r, serveFile)
+		return
+	}
+	// do a reverse proxy
+	host, location, ok, err := dt.DtSnapshotJob.isSnapshotAvailable(vars["file"], dt.Cfg, dt.DtPuller)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if ok {
+		director := func(req *http.Request) {
+			req = r
+			req.URL.Scheme = "http"
+			req.URL.Host = host
+			req.URL.Path = location
+		}
+		proxy := &httputil.ReverseProxy{Director: director}
+		proxy.ServeHTTP(w, r)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+type snapshotCreateRequest struct {
+	Version int
+	Nodes   []string
+}
+
+func writeResponse(w *http.ResponseWriter, response snapshotReportResponse, httpStatus int) {
+	response.Version = ApiVer
+	(*w).WriteHeader(httpStatus)
+	if err := json.NewEncoder(*w).Encode(response); err != nil {
+		log.Error(err)
+	}
+}
+
+func createSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	response := snapshotReportResponse{Version: ApiVer}
+	var req snapshotCreateRequest
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&req); err != nil {
+		log.Error(err)
+		response.Status = "could not unmarshal json request"
+		writeResponse(&w, response, http.StatusBadRequest)
+		return
+	}
+	if err := dt.DtSnapshotJob.run(req, dt.Cfg, dt.DtPuller, dt.DtHealth); err != nil {
+		log.Error(err)
+		response.Status = err.Error()
+		writeResponse(&w, response, http.StatusServiceUnavailable)
+		return
+	}
+	response.Status = dt.DtSnapshotJob.Status
+	response.Errors = dt.DtSnapshotJob.Errors
+	writeResponse(&w, response, http.StatusOK)
+}
+
+func logsListHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	report, err := getLogsEndpointList(dt.Cfg, dt.DtHealth)
+	if err != nil {
+		log.Error(err)
+		response := snapshotReportResponse{Version: ApiVer}
+		response.Status = err.Error()
+		writeResponse(&w, response, http.StatusNotFound)
+		return
+	}
+	if err := json.NewEncoder(w).Encode(report); err != nil {
+		log.Error("Failed to encode responses to json")
+	}
+}
+
+// return a log for past N hours for a specific systemd unit
+func getUnitLogHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	vars := mux.Vars(r)
+	unitLogOut, err := dispatchLogs(vars["provider"], vars["entity"], dt.Cfg, dt.DtHealth)
+	if err != nil {
+		log.Error(err)
+		response := snapshotReportResponse{Version: ApiVer}
+		response.Status = err.Error()
+		writeResponse(&w, response, http.StatusNotFound)
+		return
+	}
+	io.Copy(w, unitLogOut)
+}
+
 // /api/v1/system/health, get a units status, used by 3dt puller
-func unitsHealthStatus(w http.ResponseWriter, r *http.Request, config *Config) {
-	if err := json.NewEncoder(w).Encode(GlobalHealthReport.GetHealthReport()); err != nil {
+func unitsHealthStatus(w http.ResponseWriter, r *http.Request) {
+	if err := json.NewEncoder(w).Encode(GlobalUnitsHealthReport.GetHealthReport()); err != nil {
 		log.Error("Failed to encode responses to json")
 	}
 }

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -20,45 +20,43 @@ func deleteSnapshotHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
 	host, _, ok, err := dt.DtSnapshotJob.isSnapshotAvailable(vars["file"], dt.Cfg, dt.DtPuller)
 	if err != nil {
 		response.Status = vars["file"] + " not found"
-		//writeResponse(&w, response, http.StatusNotFound)
+		writeResponse(w, response, http.StatusNotFound)
 		return
 	}
 	if ok {
 		if host == fmt.Sprintf("%s:%d", dt.DtHealth.DetectIp(), dt.Cfg.FlagPort) {
 			log.Infof("Snapshot %s found on a localhost", vars["file"])
 			if err := dt.DtSnapshotJob.DeleteSnapshot(vars["file"], dt.Cfg); err != nil {
-				log.Error(err)
 				response.Status = err.Error()
-				//writeResponse(&w, response, http.StatusServiceUnavailable)
+				writeResponse(w, response, http.StatusServiceUnavailable)
 				return
 			}
 			response.Status = vars["file"] + " has been sucesfully deleted"
-			//writeResponse(&w, response, http.StatusOK)
+			writeResponse(w, response, http.StatusOK)
 			return
 		}
 		// found a snapshot on a remote host
 		url := fmt.Sprintf("http://%s%s/report/snapshot/delete/%s", host, BaseRoute, vars["file"])
-		log.Infof("POST %s", url)
+		log.Debugf("Remove a file on a remote host, sending POST %s", url)
 		req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte{}))
 		if err != nil {
-			log.Error(err)
 			response.Status = err.Error()
-			//writeResponse(&w, response, http.StatusServiceUnavailable)
+			writeResponse(w, response, http.StatusServiceUnavailable)
 			return
 		}
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {
-			log.Error(err)
 			response.Status = err.Error()
-			//writeResponse(&w, response, http.StatusServiceUnavailable)
+			writeResponse(w, response, http.StatusServiceUnavailable)
 			return
 		}
 		defer resp.Body.Close()
 		response.Status = "Removed napshot sucessfully " + vars["file"]
-		//writeResponse(&w, response, http.StatusServiceUnavailable)
+		writeResponse(w, response, http.StatusServiceUnavailable)
 		return
 	}
+	response.Status = vars["file"] + " was removed during the request"
 	http.NotFound(w, r)
 }
 
@@ -69,10 +67,11 @@ func statusSnapshotReporthandler(w http.ResponseWriter, r *http.Request, dt Dt) 
 }
 
 func statusAllSnapshotReporthandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	response := snapshotReportResponse{}
 	status, err := dt.DtSnapshotJob.getStatusAll(dt.Cfg, dt.DtPuller)
 	if err != nil {
-		log.Error(err)
-		w.WriteHeader(http.StatusBadRequest)
+		response.Status = err.Error()
+		writeResponse(w, response, http.StatusServiceUnavailable)
 		return
 	}
 	if err := json.NewEncoder(w).Encode(status); err != nil {
@@ -84,23 +83,26 @@ func cancelSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) 
 	response := snapshotReportResponse{}
 	if !dt.DtSnapshotJob.Running {
 		response.Status = "Unable to cancel, job is not running"
-		writeResponse(&w, response, http.StatusBadRequest)
+		writeResponse(w, response, http.StatusServiceUnavailable)
 		return
 	}
 	if err := dt.DtSnapshotJob.cancel(dt.DtHealth); err != nil {
 		log.Error(err)
 		response.Status = "Cancel job failed"
-		writeResponse(&w, response, http.StatusServiceUnavailable)
+		writeResponse(w, response, http.StatusServiceUnavailable)
 		return
 	}
 	response.Status = "Attempting to cancel the job, check status for more details"
-	writeResponse(&w, response, http.StatusOK)
+	writeResponse(w, response, http.StatusOK)
 }
 
 func listAllSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	response := snapshotReportResponse{}
 	allSnapshots, err := listAllSnapshots(dt.Cfg, dt.DtPuller)
 	if err != nil {
-		log.Error(err)
+		response.Status = err.Error()
+		writeResponse(w, response, http.StatusServiceUnavailable)
+		return
 	}
 	if err := json.NewEncoder(w).Encode(allSnapshots); err != nil {
 		log.Error("Failed to encode responses to json")
@@ -108,10 +110,11 @@ func listAllSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt)
 }
 
 func listSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
+	response := snapshotReportResponse{}
 	matches, err := dt.DtSnapshotJob.findLocalSnapshot(dt.Cfg)
 	if err != nil {
-		log.Error(err)
-		http.NotFound(w, r)
+		response.Status = err.Error()
+		writeResponse(w, response, http.StatusServiceUnavailable)
 		return
 	}
 
@@ -159,10 +162,11 @@ type snapshotCreateRequest struct {
 	Nodes   []string
 }
 
-func writeResponse(w *http.ResponseWriter, response snapshotReportResponse, httpStatus int) {
+func writeResponse(w http.ResponseWriter, response snapshotReportResponse, httpStatus int) {
 	response.Version = ApiVer
-	(*w).WriteHeader(httpStatus)
-	if err := json.NewEncoder(*w).Encode(response); err != nil {
+	w.WriteHeader(httpStatus)
+	log.Info(response.Status)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Error(err)
 	}
 }
@@ -172,29 +176,26 @@ func createSnapshotReportHandler(w http.ResponseWriter, r *http.Request, dt Dt) 
 	var req snapshotCreateRequest
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&req); err != nil {
-		log.Error(err)
 		response.Status = "could not unmarshal json request"
-		writeResponse(&w, response, http.StatusBadRequest)
+		writeResponse(w, response, http.StatusBadRequest)
 		return
 	}
 	if err := dt.DtSnapshotJob.run(req, dt.Cfg, dt.DtPuller, dt.DtHealth); err != nil {
-		log.Error(err)
 		response.Status = err.Error()
-		writeResponse(&w, response, http.StatusServiceUnavailable)
+		writeResponse(w, response, http.StatusServiceUnavailable)
 		return
 	}
 	response.Status = dt.DtSnapshotJob.Status
 	response.Errors = dt.DtSnapshotJob.Errors
-	writeResponse(&w, response, http.StatusOK)
+	writeResponse(w, response, http.StatusOK)
 }
 
 func logsListHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
 	report, err := getLogsEndpointList(dt.Cfg, dt.DtHealth)
 	if err != nil {
-		log.Error(err)
 		response := snapshotReportResponse{Version: ApiVer}
 		response.Status = err.Error()
-		writeResponse(&w, response, http.StatusNotFound)
+		writeResponse(w, response, http.StatusNotFound)
 		return
 	}
 	if err := json.NewEncoder(w).Encode(report); err != nil {
@@ -205,15 +206,15 @@ func logsListHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
 // return a log for past N hours for a specific systemd unit
 func getUnitLogHandler(w http.ResponseWriter, r *http.Request, dt Dt) {
 	vars := mux.Vars(r)
-	unitLogOut, err := dispatchLogs(vars["provider"], vars["entity"], dt.Cfg, dt.DtHealth)
+	doneChan, unitLogOut, err := dispatchLogs(vars["provider"], vars["entity"], dt.Cfg, dt.DtHealth)
 	if err != nil {
-		log.Error(err)
 		response := snapshotReportResponse{Version: ApiVer}
 		response.Status = err.Error()
-		writeResponse(&w, response, http.StatusNotFound)
+		writeResponse(w, response, http.StatusNotFound)
 		return
 	}
 	io.Copy(w, unitLogOut)
+	doneChan <- true
 }
 
 // /api/v1/system/health, get a units status, used by 3dt puller

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -16,7 +16,7 @@ import (
 
 // A helper function to send a response.
 func writeResponse(w http.ResponseWriter, response snapshotReportResponse) {
-	w.WriteHeader(response.responseCode)
+	w.WriteHeader(response.ResponseCode)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Error(err)
 	}

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -55,7 +55,7 @@ func (st *FakeHealthReport) GetUnitNames() (units []string, err error) {
 	return units, err
 }
 
-func (st *FakeHealthReport) GetJournalOutput(unit string) (string, error) {
+func (st *FakeHealthReport) GetJournalOutput(unit string, timeout int) (string, error) {
 	return "journal output", nil
 }
 

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -14,24 +14,23 @@ import (
 	"time"
 )
 
-// Testing SystemdType
-type FakeSystemdType struct {
+type FakeHealthReport struct {
 	units []string
 }
 
-func (st *FakeSystemdType) GetHostname() string {
+func (st *FakeHealthReport) GetHostname() string {
 	return "MyHostName"
 }
 
-func (st *FakeSystemdType) DetectIp() string {
+func (st *FakeHealthReport) DetectIp() string {
 	return "127.0.0.1"
 }
 
-func (st *FakeSystemdType) GetNodeRole() string {
+func (st *FakeHealthReport) GetNodeRole() string {
 	return "master"
 }
 
-func (st *FakeSystemdType) GetUnitProperties(pname string) (map[string]interface{}, error) {
+func (st *FakeHealthReport) GetUnitProperties(pname string) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 	st.units = append(st.units, pname)
 	if pname == "unit_to_fail" {
@@ -43,24 +42,24 @@ func (st *FakeSystemdType) GetUnitProperties(pname string) (map[string]interface
 	return result, nil
 }
 
-func (st *FakeSystemdType) InitializeDbusConnection() error {
+func (st *FakeHealthReport) InitializeDbusConnection() error {
 	return nil
 }
 
-func (st *FakeSystemdType) CloseDbusConnection() error {
+func (st *FakeHealthReport) CloseDbusConnection() error {
 	return nil
 }
 
-func (st *FakeSystemdType) GetUnitNames() (units []string, err error) {
+func (st *FakeHealthReport) GetUnitNames() (units []string, err error) {
 	units = []string{"dcos-setup.service", "dcos-link-env.service", "dcos-download.service", "unit_a", "unit_b", "unit_c", "unit_to_fail"}
 	return units, err
 }
 
-func (st *FakeSystemdType) GetJournalOutput(unit string) (string, error) {
+func (st *FakeHealthReport) GetJournalOutput(unit string) (string, error) {
 	return "journal output", nil
 }
 
-func (st *FakeSystemdType) GetMesosNodeId(role string, field string) string {
+func (st *FakeHealthReport) GetMesosNodeId(role string, field string) string {
 	return "node-id-123"
 }
 
@@ -78,8 +77,12 @@ func (suit *HandlersTestSuit) SetupTest() {
 	// setup variables
 	args := []string{"3dt", "test"}
 	suit.cfg, _ = LoadDefaultConfig(args)
-	suit.cfg.HealthReport = &FakeSystemdType{}
-	suit.router = NewRouter(&suit.cfg)
+	dt := Dt{
+		DtHealth: &FakeHealthReport{},
+		DtPuller: &FakePuller{},
+		DtSnapshotJob: &SnapshotJob{},
+	}
+	suit.router = NewRouter(dt)
 	suit.assert = assertPackage.New(suit.T())
 
 	// mock the response
@@ -219,12 +222,12 @@ func (suit *HandlersTestSuit) SetupTest() {
 
 	// Update global monitoring responses
 	GlobalMonitoringResponse.UpdateMonitoringResponse(suit.mockedMonitoringResponse)
-	GlobalHealthReport.UpdateHealthReport(suit.mockedUnitsHealthResponseJsonStruct)
+	GlobalUnitsHealthReport.UpdateHealthReport(suit.mockedUnitsHealthResponseJsonStruct)
 }
 
 func (suit *HandlersTestSuit) TearDownTest() {
 	// clear global variables that might be set
-	GlobalHealthReport = UnitsHealth{}
+	GlobalUnitsHealthReport = UnitsHealth{}
 	GlobalMonitoringResponse = MonitoringResponse{}
 }
 
@@ -251,10 +254,10 @@ func (s *HandlersTestSuit) get(url string) []byte {
 // Tests
 func (s *HandlersTestSuit) TestUnitsHealthStruct() {
 	// Test structure HealthReport get/set health report
-	GlobalHealthReport.UpdateHealthReport(UnitsHealthResponseJsonStruct{})
-	s.assert.Equal(GlobalHealthReport.GetHealthReport(), UnitsHealthResponseJsonStruct{}, "GetHealthReport() should be empty")
-	GlobalHealthReport.UpdateHealthReport(s.mockedUnitsHealthResponseJsonStruct)
-	s.assert.Equal(GlobalHealthReport.GetHealthReport(), s.mockedUnitsHealthResponseJsonStruct, "GetHealthReport() should NOT be empty")
+	GlobalUnitsHealthReport.UpdateHealthReport(UnitsHealthResponseJsonStruct{})
+	s.assert.Equal(GlobalUnitsHealthReport.GetHealthReport(), UnitsHealthResponseJsonStruct{}, "GetHealthReport() should be empty")
+	GlobalUnitsHealthReport.UpdateHealthReport(s.mockedUnitsHealthResponseJsonStruct)
+	s.assert.Equal(GlobalUnitsHealthReport.GetHealthReport(), s.mockedUnitsHealthResponseJsonStruct, "GetHealthReport() should NOT be empty")
 }
 
 func (s *HandlersTestSuit) TestUnitsHealthStatusFunc() {
@@ -458,13 +461,13 @@ func (s *HandlersTestSuit) TestIsInListFunc() {
 
 func (s *HandlersTestSuit) TestStartUpdateHealthReportActualImplementationFunc() {
 	// clear any health report
-	GlobalHealthReport.UpdateHealthReport(UnitsHealthResponseJsonStruct{})
-	s.cfg.HealthReport = &DcosHealth{}
+	GlobalUnitsHealthReport.UpdateHealthReport(UnitsHealthResponseJsonStruct{})
 
 	readyChan := make(chan bool, 1)
-	StartUpdateHealthReport(s.cfg, readyChan, true)
-	hr := GlobalHealthReport.GetHealthReport()
-	s.assert.Equal(hr, UnitsHealthResponseJsonStruct{})
+	StartUpdateHealthReport(&s.cfg, &DcosHealth{}, readyChan, true)
+
+	hr := GlobalUnitsHealthReport.GetHealthReport()
+	s.assert.Empty(hr.Array)
 }
 
 // TestCheckHealthReportRace is meant to be run under the race detector
@@ -475,10 +478,10 @@ func (s *HandlersTestSuit) TestCheckHealthReportRace() {
 	// from the main thread.
 	done := make(chan struct{})
 	go func() {
-		GlobalHealthReport.UpdateHealthReport(UnitsHealthResponseJsonStruct{})
+		GlobalUnitsHealthReport.UpdateHealthReport(UnitsHealthResponseJsonStruct{})
 		close(done)
 	}()
-	_ = GlobalHealthReport.GetHealthReport()
+	_ = GlobalUnitsHealthReport.GetHealthReport()
 	// We wait for the spawned goroutine to exit before the test
 	// returns in order to prevent the spawned goroutine from racing
 	// with TearDownTest.
@@ -487,36 +490,36 @@ func (s *HandlersTestSuit) TestCheckHealthReportRace() {
 
 func (s *HandlersTestSuit) TestStartUpdateHealthReportFunc() {
 	readyChan := make(chan bool, 1)
-	StartUpdateHealthReport(s.cfg, readyChan, true)
-	hr := GlobalHealthReport.GetHealthReport()
-	s.assert.Equal(hr, UnitsHealthResponseJsonStruct{
-		Array: []UnitHealthResponseFieldsStruct{
-			{
-				UnitId:     "unit_a",
-				UnitHealth: 0,
-				UnitTitle:  "My fake description",
-				PrettyName: "PrettyName",
-			},
-			{
-				UnitId:     "unit_b",
-				UnitHealth: 0,
-				UnitTitle:  "My fake description",
-				PrettyName: "PrettyName",
-			},
-			{
-				UnitId:     "unit_c",
-				UnitHealth: 0,
-				UnitTitle:  "My fake description",
-				PrettyName: "PrettyName",
-			},
+	f := &FakeHealthReport{}
+	StartUpdateHealthReport(&s.cfg, f, readyChan, true)
+	hr := GlobalUnitsHealthReport.GetHealthReport()
+	s.assert.Equal(hr.Array, []UnitHealthResponseFieldsStruct{
+		{
+			UnitId:     "unit_a",
+			UnitHealth: 0,
+			UnitTitle:  "My fake description",
+			PrettyName: "PrettyName",
 		},
-		Hostname:    "MyHostName",
-		IpAddress:   "127.0.0.1",
-		DcosVersion: "",
-		Role:        "master",
-		MesosId:     "node-id-123",
-		TdtVersion:  "0.0.13",
+		{
+			UnitId:     "unit_b",
+			UnitHealth: 0,
+			UnitTitle:  "My fake description",
+			PrettyName: "PrettyName",
+		},
+		{
+			UnitId:     "unit_c",
+			UnitHealth: 0,
+			UnitTitle:  "My fake description",
+			PrettyName: "PrettyName",
+		},
 	})
+	s.assert.NotEmpty(hr.System)
+	s.assert.Equal(hr.Hostname, "MyHostName")
+	s.assert.Equal(hr.IpAddress, "127.0.0.1")
+	s.assert.Equal(hr.DcosVersion, "")
+	s.assert.Equal(hr.Role, "master")
+	s.assert.Equal(hr.MesosId, "node-id-123")
+	s.assert.Equal(hr.TdtVersion, "0.1.0")
 }
 
 func TestHandlersTestSuit(t *testing.T) {

--- a/api/health.go
+++ b/api/health.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/dbus"
+	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/mem"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -16,7 +19,7 @@ import (
 )
 
 // Global health report variable
-var GlobalHealthReport UnitsHealth
+var GlobalUnitsHealthReport UnitsHealth
 
 type UnitsHealth struct {
 	sync.Mutex
@@ -35,37 +38,26 @@ func (uh *UnitsHealth) UpdateHealthReport(healthReport UnitsHealthResponseJsonSt
 	uh.healthReport = healthReport
 }
 
-// start updating health report
-func StartUpdateHealthReport(config Config, readyChan chan bool, runOnce bool) {
+func StartUpdateHealthReport(config *Config, dcosHealth HealthReporter, readyChan chan bool, runOnce bool) {
 	var ready bool
 	for {
-		healthReport, err := GetUnitsProperties(&config)
+		healthReport, err := GetUnitsProperties(config, dcosHealth)
 		if err == nil {
 			if ready == false {
 				readyChan <- true
 				ready = true
 			}
-			GlobalHealthReport.UpdateHealthReport(healthReport)
 		} else {
 			log.Error("Could not update systemd units health report")
 			log.Error(err)
 		}
+		GlobalUnitsHealthReport.UpdateHealthReport(healthReport)
 		if runOnce {
 			log.Debug("Run startUpdateHealthReport only once")
 			return
 		}
 		time.Sleep(time.Second * 60)
 	}
-}
-
-// HealthReporter implementation
-type DcosHealth struct {
-	sync.Mutex
-	dcon     *dbus.Conn
-	hostname string
-	role     string
-	ip       string
-	mesos_id string
 }
 
 func (st *DcosHealth) GetHostname() string {
@@ -270,17 +262,63 @@ func NormalizeProperty(unitName string, p map[string]interface{}, si HealthRepor
 	}
 }
 
+func updateSystemMetrics() (sysMetrics SysMetrics, err error) {
+	var globalError string
+	v, err := mem.VirtualMemory()
+	if err == nil {
+		sysMetrics.Memory = *v
+	} else {
+		globalError += err.Error()
+	}
+
+	la, err := load.Avg()
+	if err == nil {
+		sysMetrics.LoadAvarage = *la
+	} else {
+		globalError += err.Error()
+	}
+	d, err := disk.Partitions(true)
+	if err == nil {
+		sysMetrics.Partitions = d
+	} else {
+		globalError += err.Error()
+		return sysMetrics, errors.New(globalError)
+	}
+
+	var diskUsage []disk.UsageStat
+	for _, diskProps := range d {
+		currentDiskUsage, err := disk.Usage(diskProps.Mountpoint)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		if currentDiskUsage.String() == "" {
+			continue
+		}
+		diskUsage = append(diskUsage, *currentDiskUsage)
+	}
+	sysMetrics.DiskUsage = diskUsage
+	return sysMetrics, nil
+}
+
 // endpoint "/api/v1/system/health"
-func GetUnitsProperties(config *Config) (UnitsHealthResponseJsonStruct, error) {
+func GetUnitsProperties(config *Config, dcosHealth HealthReporter) (healthReport UnitsHealthResponseJsonStruct, err error) {
+	// update system metrics first to make sure we always return them.
+	sysMetrics, err := updateSystemMetrics()
+	if err != nil {
+		log.Error(err)
+	}
+	healthReport.System = sysMetrics
+
 	// detect DC/OS systemd units
-	foundUnits, err := config.HealthReport.GetUnitNames()
+	foundUnits, err := dcosHealth.GetUnitNames()
 	if err != nil {
 		log.Error(err)
 	}
 	var allUnitsProperties []UnitHealthResponseFieldsStruct
 	// open dbus connection
-	if err = config.HealthReport.InitializeDbusConnection(); err != nil {
-		return UnitsHealthResponseJsonStruct{}, err
+	if err = dcosHealth.InitializeDbusConnection(); err != nil {
+		return healthReport, err
 	}
 	log.Debug("Opened dbus connection")
 
@@ -293,25 +331,26 @@ func GetUnitsProperties(config *Config) (UnitsHealthResponseJsonStruct, error) {
 			log.Debugf("Skipping blacklisted systemd unit %s", unit)
 			continue
 		}
-		currentProperty, err := config.HealthReport.GetUnitProperties(unit)
+		currentProperty, err := dcosHealth.GetUnitProperties(unit)
 		if err != nil {
 			log.Errorf("Could not get properties for unit: %s", unit)
 			continue
 		}
-		allUnitsProperties = append(allUnitsProperties, NormalizeProperty(unit, currentProperty, config.HealthReport))
+		allUnitsProperties = append(allUnitsProperties, NormalizeProperty(unit, currentProperty, dcosHealth))
 	}
 	// after we finished querying systemd units, close dbus connection
-	if err = config.HealthReport.CloseDbusConnection(); err != nil {
+	if err = dcosHealth.CloseDbusConnection(); err != nil {
 		// we should probably return here, since we cannot guarantee that all units have been queried.
-		return UnitsHealthResponseJsonStruct{}, err
+		return healthReport, err
 	}
 	return UnitsHealthResponseJsonStruct{
 		Array:       allUnitsProperties,
-		Hostname:    config.HealthReport.GetHostname(),
-		IpAddress:   config.HealthReport.DetectIp(),
+		System:      sysMetrics,
+		Hostname:    dcosHealth.GetHostname(),
+		IpAddress:   dcosHealth.DetectIp(),
 		DcosVersion: config.DcosVersion,
-		Role:        config.HealthReport.GetNodeRole(),
-		MesosId:     config.HealthReport.GetMesosNodeId(config.HealthReport.GetNodeRole(), "id"),
+		Role:        dcosHealth.GetNodeRole(),
+		MesosId:     dcosHealth.GetMesosNodeId(dcosHealth.GetNodeRole(), "id"),
 		TdtVersion:  config.Version,
 	}, nil
 }

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"time"
+	log "github.com/Sirupsen/logrus"
+	"net/http"
+	"io/ioutil"
+	"io"
+)
+
+// Implementation of HTTPRequester
+type HTTPRequest struct {}
+
+func (h *HTTPRequest) doRequest(method, url string, timeout time.Duration, body io.Reader) (responseBody []byte, httpResponseCode int, err error){
+	request, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return responseBody, http.StatusBadRequest, err
+	}
+
+	resp, err := h.MakeRequest(request, timeout)
+	if err != nil {
+		return responseBody, http.StatusBadRequest, err
+	}
+
+	defer resp.Body.Close()
+	responseBody, err = ioutil.ReadAll(resp.Body)
+	return responseBody, resp.StatusCode, nil
+}
+
+func (h *HTTPRequest) Get(url string, timeout time.Duration) (body []byte, httpResponseCode int, err error) {
+	log.Debugf("GET %s, timeout: %s", url, timeout.String())
+	return h.doRequest("GET", url, timeout, nil)
+
+}
+
+func (h *HTTPRequest) Post(url string, timeout time.Duration) (body []byte, httpResponseCode int, err error) {
+	log.Debugf("POST %s, timeout: %s", url, timeout.String())
+	return h.doRequest("POST", url, timeout, nil)
+}
+
+func (h *HTTPRequest) MakeRequest(req *http.Request, timeout time.Duration) (resp *http.Response, err error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err = client.Do(req)
+	if err != nil {
+		return resp, err
+	}
+	// the user of this function is responsible to close the response body.
+	return resp, nil
+}

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -11,7 +11,7 @@ type Puller interface {
 	GetAgentsFromMaster() ([]Node, error)
 
 	// functions make a GET request to a remote node, return an array of response, response status and error
-	GetUnitsPropertiesViaHttp(string) ([]byte, int, error)
+	GetHttp(string) ([]byte, int, error)
 
 	// function to wait between pulls
 	WaitBetweenPulls(int)

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -1,6 +1,9 @@
 package api
 
-import "time"
+import (
+	"time"
+	"net/http"
+)
 
 // Puller interface
 type Puller interface {
@@ -9,9 +12,6 @@ type Puller interface {
 
 	// function gets a list of agents from master.mesos:5050/slaves, append to *[]Host
 	GetAgentsFromMaster() ([]Node, error)
-
-	// functions make a GET request to a remote node, return an array of response, response status and error
-	GetHttp(string) ([]byte, int, error)
 
 	// function to wait between pulls
 	WaitBetweenPulls(int)
@@ -56,4 +56,15 @@ type HealthReporter interface {
 type agentResponder interface {
 	getAgentSource() ([]string, error)
 	getMesosAgents([]string) ([]Node, error)
+}
+
+//
+type HTTPRequester interface {
+	// Make a GET request pass url, returns a list of bytes, http response code and error
+	Get(string, time.Duration) ([]byte, int, error)
+	Post(string, time.Duration) ([]byte, int, error)
+
+	// Make a HTTP request pass timeout, http.Request object, returns a *http.Response and error.
+	// Caller is responsible for calling http.Response.Body().Close()
+	MakeRequest(*http.Request, time.Duration) (*http.Response, error)
 }

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -46,7 +46,7 @@ type HealthReporter interface {
 	GetUnitNames() ([]string, error)
 
 	// Get journal output
-	GetJournalOutput(string) (string, error)
+	GetJournalOutput(string, int) (string, error)
 
 	// Get mesos node id, first argument is a role, second argument is a json field name
 	GetMesosNodeId(string, string) string

--- a/api/pull.go
+++ b/api/pull.go
@@ -22,7 +22,7 @@ func (pt *PullType) GetTimestamp() time.Time {
 	return time.Now()
 }
 
-func (pt *PullType) GetUnitsPropertiesViaHttp(url string) ([]byte, int, error) {
+func (pt *PullType) GetHttp(url string) ([]byte, int, error) {
 	var body []byte
 
 	// a timeout of 1 seconds should be good enough
@@ -373,20 +373,20 @@ func (mr *MonitoringResponse) GetNodeUnitByNodeIdUnitId(nodeIp string, unitId st
 }
 
 // entry point to pull
-func StartPullWithInterval(config Config, pi Puller, ready chan bool) {
+func StartPullWithInterval(dt Dt, ready chan bool) {
 	select {
 	case r := <-ready:
 		if r == true {
-			log.Info(fmt.Sprintf("Start pulling with interval %d", config.FlagPullInterval))
+			log.Info(fmt.Sprintf("Start pulling with interval %d", dt.Cfg.FlagPullInterval))
 			for {
-				runPull(config.FlagPullInterval, config.FlagPort, pi)
+				runPull(dt.Cfg.FlagPullInterval, dt.Cfg.FlagPort, dt.DtPuller)
 			}
 
 		}
 	case <-time.After(time.Second * 10):
 		log.Error("Not ready to pull from localhost after 10 seconds")
 		for {
-			runPull(config.FlagPullInterval, config.FlagPort, pi)
+			runPull(dt.Cfg.FlagPullInterval, dt.Cfg.FlagPort, dt.DtPuller)
 		}
 	}
 }
@@ -504,7 +504,7 @@ func pullHostStatus(hosts <-chan Node, respChan chan<- *HttpResponse, port int, 
 
 		// Make a request to get node units status
 		// use fake interface implementation for tests
-		body, statusCode, err := pi.GetUnitsPropertiesViaHttp(url)
+		body, statusCode, err := pi.GetHttp(url)
 		if err != nil {
 			log.Error(err)
 			response.Status = 500

--- a/api/pull.go
+++ b/api/pull.go
@@ -22,33 +22,6 @@ func (pt *PullType) GetTimestamp() time.Time {
 	return time.Now()
 }
 
-func makeRequest(timeout time.Duration, req *http.Request) (resp *http.Response, err error) {
-	client := http.Client{
-		Timeout: timeout,
-	}
-	resp, err = client.Do(req)
-	if err != nil {
-		return resp, err
-	}
-	// the user of this function is responsible to close the response.
-	return resp, nil
-}
-
-func (pt *PullType) GetHttp(url string) (body []byte, statusCode int, err error) {
-	request, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return body, 500, err
-	}
-	timeout := time.Duration(time.Second*3)
-	resp, err := makeRequest(timeout, request)
-	if err != nil {
-		return body, 500, err
-	}
-	defer resp.Body.Close()
-	body, err = ioutil.ReadAll(resp.Body)
-	return body, resp.StatusCode, nil
-}
-
 func (pt *PullType) LookupMaster() (nodes_response []Node, err error) {
 	url := "http://127.0.0.1:8181/exhibitor/v1/cluster/status"
 	client := http.Client{Timeout: time.Duration(time.Second)}
@@ -387,33 +360,33 @@ func StartPullWithInterval(dt Dt, ready chan bool) {
 		if r == true {
 			log.Info(fmt.Sprintf("Start pulling with interval %d", dt.Cfg.FlagPullInterval))
 			for {
-				runPull(dt.Cfg.FlagPullInterval, dt.Cfg.FlagPort, dt.DtPuller)
+				runPull(dt.Cfg.FlagPullInterval, dt.Cfg.FlagPort, dt)
 			}
 
 		}
 	case <-time.After(time.Second * 10):
 		log.Error("Not ready to pull from localhost after 10 seconds")
 		for {
-			runPull(dt.Cfg.FlagPullInterval, dt.Cfg.FlagPort, dt.DtPuller)
+			runPull(dt.Cfg.FlagPullInterval, dt.Cfg.FlagPort, dt)
 		}
 	}
 }
 
-func runPull(sec int, port int, pi Puller) {
+func runPull(sec int, port int, dt Dt) {
 	var ClusterHosts []Node
-	masterNodes, err := pi.LookupMaster()
+	masterNodes, err := dt.DtPuller.LookupMaster()
 	if err != nil {
 		log.Error(err)
 		log.Warningf("Could not get a list of master nodes, waiting %d sec", sec)
-		pi.WaitBetweenPulls(sec)
+		dt.DtPuller.WaitBetweenPulls(sec)
 		return
 	}
 
-	agentNodes, err := pi.GetAgentsFromMaster()
+	agentNodes, err := dt.DtPuller.GetAgentsFromMaster()
 	if err != nil {
 		log.Error(err)
 		log.Warningf("Could not get a list of agent nodes, waiting %d sec", sec)
-		pi.WaitBetweenPulls(sec)
+		dt.DtPuller.WaitBetweenPulls(sec)
 		return
 	}
 
@@ -426,21 +399,21 @@ func runPull(sec int, port int, pi Puller) {
 
 	// Pull data from each host
 	for i := 0; i <= len(ClusterHosts); i++ {
-		go pullHostStatus(hostsChan, respChan, port, pi)
+		go pullHostStatus(hostsChan, respChan, port, dt)
 	}
 
 	// blocking here got get all responses from hosts
 	ClusterHttpResponses := collectResponses(respChan, len(ClusterHosts))
 
 	// update collected units/nodes health statuses
-	updateHealthStatus(ClusterHttpResponses, pi)
+	updateHealthStatus(ClusterHttpResponses)
 
 	log.Debug(fmt.Sprintf("Waiting %d seconds before next pull", sec))
-	pi.WaitBetweenPulls(sec)
+	dt.DtPuller.WaitBetweenPulls(sec)
 }
 
 // function builds a map of all unique units with status
-func updateHealthStatus(responses []*HttpResponse, pi Puller) {
+func updateHealthStatus(responses []*HttpResponse) {
 	units := make(map[string]*Unit)
 	nodes := make(map[string]*Node)
 
@@ -503,7 +476,7 @@ func collectResponses(respChan <-chan *HttpResponse, totalHosts int) (responses 
 	}
 }
 
-func pullHostStatus(hosts <-chan Node, respChan chan<- *HttpResponse, port int, pi Puller) {
+func pullHostStatus(hosts <-chan Node, respChan chan<- *HttpResponse, port int, dt Dt) {
 	for host := range hosts {
 		var response HttpResponse
 
@@ -512,10 +485,10 @@ func pullHostStatus(hosts <-chan Node, respChan chan<- *HttpResponse, port int, 
 
 		// Make a request to get node units status
 		// use fake interface implementation for tests
-		body, statusCode, err := pi.GetHttp(url)
+		body, statusCode, err := dt.HTTPRequest.Get(url, time.Duration(time.Second*3))
 		if err != nil {
 			log.Error(err)
-			response.Status = 500
+			response.Status = statusCode
 			host.Health = 3 // 3 stands for unknown
 			respChan <- &response
 			response.Node = host
@@ -558,7 +531,7 @@ func pullHostStatus(hosts <-chan Node, respChan chan<- *HttpResponse, port int, 
 				[]Node{host},
 				propertiesMap.UnitHealth,
 				propertiesMap.UnitTitle,
-				pi.GetTimestamp(),
+				dt.DtPuller.GetTimestamp(),
 				propertiesMap.PrettyName,
 			})
 		}

--- a/api/pull.go
+++ b/api/pull.go
@@ -398,7 +398,7 @@ func runPull(sec int, port int, dt Dt) {
 	loadJobs(hostsChan, ClusterHosts)
 
 	// Pull data from each host
-	for i := 0; i <= len(ClusterHosts); i++ {
+	for i := 1; i <= len(ClusterHosts); i++ {
 		go pullHostStatus(hostsChan, respChan, port, dt)
 	}
 

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -14,6 +14,7 @@ type FakePuller struct {
 	test              bool
 	urls              []string
 	fakeHttpResponses []*HttpResponse
+	mockedNode        Node
 }
 
 func (pt *FakePuller) GetTimestamp() time.Time {
@@ -21,6 +22,9 @@ func (pt *FakePuller) GetTimestamp() time.Time {
 }
 
 func (pt *FakePuller) LookupMaster() (nodes []Node, err error) {
+	if pt.mockedNode.Ip != "" {
+		return []Node{pt.mockedNode}, nil
+	}
 	var fakeMasterHost Node
 	fakeMasterHost.Ip = "127.0.0.1"
 	fakeMasterHost.Role = "master"
@@ -35,95 +39,6 @@ func (pt *FakePuller) GetAgentsFromMaster() (nodes []Node, err error) {
 	nodes = append(nodes, fakeAgentHost)
 	return nodes, nil
 }
-
-//func (pt *FakePuller) GetHttp(url string) ([]byte, int, error) {
-//	var response string
-//
-//	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/status", BaseRoute) {
-//		response = `
-//			{
-//			  "is_running":true,
-//			  "status":"MyStatus",
-//			  "errors":null,
-//			  "last_snapshot_dir":"/path/to/snapshot",
-//			  "job_started":"0001-01-01 00:00:00 +0000 UTC",
-//			  "job_ended":"0001-01-01 00:00:00 +0000 UTC",
-//			  "job_duration":"2s",
-//			  "snapshot_dir":"/home/core/1",
-//			  "snapshot_job_timeout_min":720,
-//			  "snapshot_partition_disk_usage_percent":28.0,
-//			  "journald_logs_since_hours": "24",
-//			  "snapshot_job_get_since_url_timeout_min": 5,
-//			  "command_exec_timeout_sec": 10
-//			}
-//		`
-//	}
-//	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/list", BaseRoute) {
-//		response = `["/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"]`
-//	}
-//	// master
-//	if url == fmt.Sprintf("http://127.0.0.1:1050%s", BaseRoute) {
-//		response = `
-//			{
-//			  "units": [
-//			    {
-//			      "id":"dcos-setup.service",
-//			      "health":0,
-//			      "output":"",
-//			      "description":"Nice Description.",
-//			      "help":"",
-//			      "name":"PrettyName"
-//			    },
-//			    {
-//			      "id":"dcos-master.service",
-//			      "health":0,
-//			      "output":"",
-//			      "description":"Nice Master Description.",
-//			      "help":"",
-//			      "name":"PrettyName"
-//			    }
-//			  ],
-//			  "hostname":"master01",
-//			  "ip":"127.0.0.1",
-//			  "dcos_version":"1.6",
-//			  "node_role":"master",
-//			  "mesos_id":"master-123",
-//			  "3dt_version": "0.0.7"
-//			}`
-//	}
-//
-//	// agent
-//	if url == fmt.Sprintf("http://127.0.0.2:1050%s", BaseRoute) {
-//		response = `
-//			{
-//			  "units": [
-//			    {
-//			      "id":"dcos-setup.service",
-//			      "health":0,
-//			      "output":"",
-//			      "description":"Nice Description.",
-//			      "help":"",
-//			      "name":"PrettyName"
-//			    },
-//			    {
-//			      "id":"dcos-agent.service",
-//			      "health":1,
-//			      "output":"",
-//			      "description":"Nice Agent Description.",
-//			      "help":"",
-//			      "name":"PrettyName"
-//			    }
-//			  ],
-//			  "hostname":"agent01",
-//			  "ip":"127.0.0.2",
-//			  "dcos_version":"1.6",
-//			  "node_role":"agent",
-//			  "mesos_id":"agent-123",
-//			  "3dt_version": "0.0.7"
-//			}`
-//	}
-//	return []byte(response), 200, nil
-//}
 
 func (pt *FakePuller) WaitBetweenPulls(interval int) {
 }

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -51,23 +51,17 @@ func (pt *FakePuller) GetHttp(url string) ([]byte, int, error) {
 			  "job_ended":"0001-01-01 00:00:00 +0000 UTC",
 			  "job_duration":"2s",
 			  "snapshot_dir":"/home/core/1",
-			  "job_timeout_min":720,
-			  "snapshot_partition_disk_usage_percent":28.0
+			  "snapshot_job_timeout_min":720,
+			  "snapshot_partition_disk_usage_percent":28.0,
+			  "journald_logs_since_hours": "24",
+			  "snapshot_job_get_since_url_timeout_min": 5,
+			  "command_exec_timeout_sec": 10
 			}
 		`
 	}
 	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/list", BaseRoute) {
 		response = `["/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"]`
 	}
-	//	response = `
-	//		{
-	//		  "127.0.0.1:1050": [
-	//		    "/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"
-	//		  ],
-	//		  "10.0.7.122:1050":null,
-	//		  "10.0.7.123:1050":null
-	//		}`
-	//}
 	// master
 	if url == fmt.Sprintf("http://127.0.0.1:1050%s", BaseRoute) {
 		response = `

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -37,9 +37,37 @@ func (pt *FakePuller) GetAgentsFromMaster() (nodes []Node, err error) {
 	return nodes, nil
 }
 
-func (pt *FakePuller) GetUnitsPropertiesViaHttp(url string) ([]byte, int, error) {
+func (pt *FakePuller) GetHttp(url string) ([]byte, int, error) {
 	var response string
 
+	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/status", BaseRoute) {
+		response = `
+			{
+			  "is_running":true,
+			  "status":"MyStatus",
+			  "errors":null,
+			  "last_snapshot_dir":"/path/to/snapshot",
+			  "job_started":"0001-01-01 00:00:00 +0000 UTC",
+			  "job_ended":"0001-01-01 00:00:00 +0000 UTC",
+			  "job_duration":"2s",
+			  "snapshot_dir":"/home/core/1",
+			  "job_timeout_min":720,
+			  "snapshot_partition_disk_usage_percent":28.0
+			}
+		`
+	}
+	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/list", BaseRoute) {
+		response = `["/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"]`
+	}
+	//	response = `
+	//		{
+	//		  "127.0.0.1:1050": [
+	//		    "/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"
+	//		  ],
+	//		  "10.0.7.122:1050":null,
+	//		  "10.0.7.123:1050":null
+	//		}`
+	//}
 	// master
 	if url == fmt.Sprintf("http://127.0.0.1:1050%s", BaseRoute) {
 		response = `

--- a/api/pull_test.go
+++ b/api/pull_test.go
@@ -2,12 +2,11 @@ package api
 
 import (
 	// intentionally rename package to do some magic
-	"fmt"
 	assertPackage "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"sync"
 	"testing"
 	"time"
+	"sync"
 )
 
 // Fake Interface and implementation for Pulling functionality
@@ -37,94 +36,94 @@ func (pt *FakePuller) GetAgentsFromMaster() (nodes []Node, err error) {
 	return nodes, nil
 }
 
-func (pt *FakePuller) GetHttp(url string) ([]byte, int, error) {
-	var response string
-
-	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/status", BaseRoute) {
-		response = `
-			{
-			  "is_running":true,
-			  "status":"MyStatus",
-			  "errors":null,
-			  "last_snapshot_dir":"/path/to/snapshot",
-			  "job_started":"0001-01-01 00:00:00 +0000 UTC",
-			  "job_ended":"0001-01-01 00:00:00 +0000 UTC",
-			  "job_duration":"2s",
-			  "snapshot_dir":"/home/core/1",
-			  "snapshot_job_timeout_min":720,
-			  "snapshot_partition_disk_usage_percent":28.0,
-			  "journald_logs_since_hours": "24",
-			  "snapshot_job_get_since_url_timeout_min": 5,
-			  "command_exec_timeout_sec": 10
-			}
-		`
-	}
-	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/list", BaseRoute) {
-		response = `["/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"]`
-	}
-	// master
-	if url == fmt.Sprintf("http://127.0.0.1:1050%s", BaseRoute) {
-		response = `
-			{
-			  "units": [
-			    {
-			      "id":"dcos-setup.service",
-			      "health":0,
-			      "output":"",
-			      "description":"Nice Description.",
-			      "help":"",
-			      "name":"PrettyName"
-			    },
-			    {
-			      "id":"dcos-master.service",
-			      "health":0,
-			      "output":"",
-			      "description":"Nice Master Description.",
-			      "help":"",
-			      "name":"PrettyName"
-			    }
-			  ],
-			  "hostname":"master01",
-			  "ip":"127.0.0.1",
-			  "dcos_version":"1.6",
-			  "node_role":"master",
-			  "mesos_id":"master-123",
-			  "3dt_version": "0.0.7"
-			}`
-	}
-
-	// agent
-	if url == fmt.Sprintf("http://127.0.0.2:1050%s", BaseRoute) {
-		response = `
-			{
-			  "units": [
-			    {
-			      "id":"dcos-setup.service",
-			      "health":0,
-			      "output":"",
-			      "description":"Nice Description.",
-			      "help":"",
-			      "name":"PrettyName"
-			    },
-			    {
-			      "id":"dcos-agent.service",
-			      "health":1,
-			      "output":"",
-			      "description":"Nice Agent Description.",
-			      "help":"",
-			      "name":"PrettyName"
-			    }
-			  ],
-			  "hostname":"agent01",
-			  "ip":"127.0.0.2",
-			  "dcos_version":"1.6",
-			  "node_role":"agent",
-			  "mesos_id":"agent-123",
-			  "3dt_version": "0.0.7"
-			}`
-	}
-	return []byte(response), 200, nil
-}
+//func (pt *FakePuller) GetHttp(url string) ([]byte, int, error) {
+//	var response string
+//
+//	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/status", BaseRoute) {
+//		response = `
+//			{
+//			  "is_running":true,
+//			  "status":"MyStatus",
+//			  "errors":null,
+//			  "last_snapshot_dir":"/path/to/snapshot",
+//			  "job_started":"0001-01-01 00:00:00 +0000 UTC",
+//			  "job_ended":"0001-01-01 00:00:00 +0000 UTC",
+//			  "job_duration":"2s",
+//			  "snapshot_dir":"/home/core/1",
+//			  "snapshot_job_timeout_min":720,
+//			  "snapshot_partition_disk_usage_percent":28.0,
+//			  "journald_logs_since_hours": "24",
+//			  "snapshot_job_get_since_url_timeout_min": 5,
+//			  "command_exec_timeout_sec": 10
+//			}
+//		`
+//	}
+//	if url == fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/list", BaseRoute) {
+//		response = `["/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"]`
+//	}
+//	// master
+//	if url == fmt.Sprintf("http://127.0.0.1:1050%s", BaseRoute) {
+//		response = `
+//			{
+//			  "units": [
+//			    {
+//			      "id":"dcos-setup.service",
+//			      "health":0,
+//			      "output":"",
+//			      "description":"Nice Description.",
+//			      "help":"",
+//			      "name":"PrettyName"
+//			    },
+//			    {
+//			      "id":"dcos-master.service",
+//			      "health":0,
+//			      "output":"",
+//			      "description":"Nice Master Description.",
+//			      "help":"",
+//			      "name":"PrettyName"
+//			    }
+//			  ],
+//			  "hostname":"master01",
+//			  "ip":"127.0.0.1",
+//			  "dcos_version":"1.6",
+//			  "node_role":"master",
+//			  "mesos_id":"master-123",
+//			  "3dt_version": "0.0.7"
+//			}`
+//	}
+//
+//	// agent
+//	if url == fmt.Sprintf("http://127.0.0.2:1050%s", BaseRoute) {
+//		response = `
+//			{
+//			  "units": [
+//			    {
+//			      "id":"dcos-setup.service",
+//			      "health":0,
+//			      "output":"",
+//			      "description":"Nice Description.",
+//			      "help":"",
+//			      "name":"PrettyName"
+//			    },
+//			    {
+//			      "id":"dcos-agent.service",
+//			      "health":1,
+//			      "output":"",
+//			      "description":"Nice Agent Description.",
+//			      "help":"",
+//			      "name":"PrettyName"
+//			    }
+//			  ],
+//			  "hostname":"agent01",
+//			  "ip":"127.0.0.2",
+//			  "dcos_version":"1.6",
+//			  "node_role":"agent",
+//			  "mesos_id":"agent-123",
+//			  "3dt_version": "0.0.7"
+//			}`
+//	}
+//	return []byte(response), 200, nil
+//}
 
 func (pt *FakePuller) WaitBetweenPulls(interval int) {
 }
@@ -136,13 +135,16 @@ func (pt *FakePuller) UpdateHttpResponses(responses []*HttpResponse) {
 type PullerTestSuit struct {
 	suite.Suite
 	assert *assertPackage.Assertions
-	puller *FakePuller
+	dt     Dt
 }
 
 func (suit *PullerTestSuit) SetupTest() {
 	suit.assert = assertPackage.New(suit.T())
-	suit.puller = &FakePuller{}
-	runPull(1, 1050, suit.puller)
+	suit.dt = Dt{
+		DtPuller: &FakePuller{},
+		HTTPRequest: &FakeHTTPRequest{},
+	}
+	runPull(1, 1050, suit.dt)
 }
 
 func (suit *PullerTestSuit) TearDownTest() {

--- a/api/router.go
+++ b/api/router.go
@@ -130,7 +130,7 @@ func getRoutes(dt Dt) []routeHandler {
 			// /system/health/v1/report/snapshot
 			url: BaseRoute + "/report/snapshot/create",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				createSnapshotReportHandler(w, r, dt)
+				createSnapshotHandler(w, r, dt)
 			},
 			methods: []string{"POST"},
 		},
@@ -157,14 +157,14 @@ func getRoutes(dt Dt) []routeHandler {
 			// /system/health/v1/report/snapshot/list
 			url: BaseRoute + "/report/snapshot/list",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				listSnapshotReportHandler(w, r, dt)
+				listAvailableLocalSnapshotFilesHandler(w, r, dt)
 			},
 		},
 		{
 			// /system/health/v1/report/snapshot/list/all
 			url: BaseRoute + "/report/snapshot/list/all",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				listAllSnapshotReportHandler(w, r, dt)
+				listAvailableGLobalSnapshotFilesHandler(w, r, dt)
 			},
 		},
 		{

--- a/api/router.go
+++ b/api/router.go
@@ -1,18 +1,22 @@
 package api
 
 import (
-	"fmt"
-
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"fmt"
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 )
 
+const ApiVer int = 1
 const BaseRoute string = "/system/health/v1"
 
 type routeHandler struct {
 	url     string
 	handler func(http.ResponseWriter, *http.Request)
 	headers []header
+	methods []string
+	gzip    bool
 }
 
 type header struct {
@@ -22,26 +26,27 @@ type header struct {
 
 func headerMiddleware(next http.Handler, headers []header) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defaultHeaders := []header{
-			{
-				name:  "Content-type",
-				value: "application/json",
-			},
-		}
-		for _, header := range append(defaultHeaders, headers...) {
+		setJsonContentType := true
+		for _, header := range headers {
+			if header.name == "Content-type" {
+				setJsonContentType = false
+			}
 			w.Header().Add(header.name, header.value)
+		}
+		if setJsonContentType {
+			w.Header().Add("Content-type", "application/json")
 		}
 		next.ServeHTTP(w, r)
 	})
 }
 
-func getRoutes(config *Config) []routeHandler {
+func getRoutes(dt Dt) []routeHandler {
 	return []routeHandler{
 		{
 			// /system/health/v1
 			url: BaseRoute,
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				unitsHealthStatus(w, r, config)
+				unitsHealthStatus(w, r)
 			},
 		},
 		{
@@ -100,18 +105,112 @@ func getRoutes(config *Config) []routeHandler {
 			url:     fmt.Sprintf("%s/nodes/{nodeid}/units/{unitid}", BaseRoute),
 			handler: getNodeUnitByNodeIdUnitIdHandler,
 		},
+		{
+			// /system/health/v1/logs
+			url: BaseRoute + "/logs",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				logsListHandler(w, r, dt)
+			},
+		},
+		{
+			// /system/health/v1/logs/<unitid/<hours>
+			url:     BaseRoute + "/logs/{provider}/{entity}",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				getUnitLogHandler(w, r, dt)
+			},
+			headers: []header{
+				{
+					name:  "Content-type",
+					value: "text/html",
+				},
+			},
+			gzip: true,
+		},
+		{
+			// /system/health/v1/report/snapshot
+			url: BaseRoute + "/report/snapshot/create",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				createSnapshotReportHandler(w, r, dt)
+			},
+			methods: []string{"POST"},
+		},
+		{
+			url: BaseRoute + "/report/snapshot/cancel",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				cancelSnapshotReportHandler(w, r, dt)
+			},
+			methods: []string{"POST"},
+		},
+		{
+			url: BaseRoute + "/report/snapshot/status",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				statusSnapshotReporthandler(w, r, dt)
+			},
+		},
+		{
+			url: BaseRoute + "/report/snapshot/status/all",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				statusAllSnapshotReporthandler(w, r, dt)
+			},
+		},
+		{
+			// /system/health/v1/report/snapshot/list
+			url: BaseRoute + "/report/snapshot/list",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				listSnapshotReportHandler(w, r, dt)
+			},
+		},
+		{
+			// /system/health/v1/report/snapshot/list/all
+			url: BaseRoute + "/report/snapshot/list/all",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				listAllSnapshotReportHandler(w, r, dt)
+			},
+		},
+		{
+			// /system/health/v1/report/snapshot/serve/<file>
+			url: BaseRoute + "/report/snapshot/serve/{file}",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				downloadSnapshotHandler(w, r, dt)
+			},
+			headers: []header{
+				{
+					name:  "Content-type",
+					value: "application/octet-stream",
+				},
+			},
+		},
+		{
+			// /system/health/v1/report/snapshot/delete/<file>
+			url: BaseRoute + "/report/snapshot/delete/{file}",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				deleteSnapshotHandler(w, r, dt)
+			},
+			methods: []string{"POST"},
+		},
 	}
 }
 
-func loadRoutes(router *mux.Router, config *Config) *mux.Router {
-	for _, route := range getRoutes(config) {
+func wrapHandler(handler http.Handler, route routeHandler) http.Handler {
+	handlerWithHeader := headerMiddleware(handler, route.headers)
+	if route.gzip {
+		return handlers.CompressHandler(handlerWithHeader)
+	}
+	return handlerWithHeader
+}
+
+func loadRoutes(router *mux.Router, dt Dt) *mux.Router {
+	for _, route := range getRoutes(dt) {
+		if len(route.methods) == 0 {
+			route.methods = []string{"GET"}
+		}
 		handler := http.HandlerFunc(route.handler)
-		router.Handle(route.url, headerMiddleware(handler, route.headers)).Methods("GET")
+		router.Handle(route.url, wrapHandler(handler, route)).Methods(route.methods...)
 	}
 	return router
 }
 
-func NewRouter(config *Config) *mux.Router {
+func NewRouter(dt Dt) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	return loadRoutes(router, config)
+	return loadRoutes(router, dt)
 }

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -256,6 +256,8 @@ func (j *SnapshotJob) delete(snapshotName string, config *Config, puller Puller,
 }
 
 func (j *SnapshotJob) run(req snapshotCreateRequest, config *Config, puller Puller, dcosHealth HealthReporter) error {
+	// reset job status every time we run a new job.
+	*j = SnapshotJob{}
 	if dcosHealth.GetNodeRole() == "agent" {
 		return errors.New("Running snapshot job on agent node is not implemented.")
 	}
@@ -310,7 +312,6 @@ func updateSummaryReport(preflix string, node Node, error string, r *bytes.Buffe
 
 func (j *SnapshotJob) runBackgroundReport(nodes []Node, config *Config, puller Puller) {
 	log.Info("Started background job")
-
 	// log a start time
 	j.JobStarted = time.Now()
 

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -20,18 +20,6 @@ import (
 	"time"
 )
 
-func makeRequest(timeout time.Duration, req *http.Request) (resp *http.Response, err error) {
-	client := http.Client{
-		Timeout: timeout,
-	}
-	resp, err = client.Do(req)
-	if err != nil {
-		return resp, err
-	}
-	// the user of this function is responsible to close the response.
-	return resp, nil
-}
-
 // snapshotJob
 type SnapshotJob struct {
 	sync.Mutex

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -42,20 +42,23 @@ type snapshotReportResponse struct {
 
 type snapshotReportStatus struct {
 	// job related fields
-	Running          bool     `json:"is_running"`
-	Status           string   `json:"status"`
-	Errors           []string `json:"errors"`
-	LastSnapshotPath string   `json:"last_snapshot_dir"`
-	JobStarted       string   `json:"job_started"`
-	JobEnded         string   `json:"job_ended"`
-	JobDuration      string   `json:"job_duration"`
+	Running                              bool     `json:"is_running"`
+	Status                               string   `json:"status"`
+	Errors                               []string `json:"errors"`
+	LastSnapshotPath                      string   `json:"last_snapshot_dir"`
+	JobStarted                            string   `json:"job_started"`
+	JobEnded                              string   `json:"job_ended"`
+	JobDuration                           string   `json:"job_duration"`
 
 	// config related fields
-	SnapshotBaseDir       string `json:"snapshot_dir"`
-	SnapshotJobTimeoutMin int    `json:"job_timeout_min"`
+	SnapshotBaseDir                       string `json:"snapshot_dir"`
+	SnapshotJobTimeoutMin                 int    `json:"snapshot_job_timeout_min"`
+	SnapshotUnitsLogsSinceHours           string `json:"journald_logs_since_hours"`
+	SnapshotJobGetSingleUrlTimeoutMinutes int `json:"snapshot_job_get_since_url_timeout_min"`
+	CommandExecTimeoutSec                 int `json:"command_exec_timeout_sec"`
 
 	// metrics related
-	DiskUsedPercent float64 `json:"snapshot_partition_disk_usage_percent"`
+	DiskUsedPercent                       float64 `json:"snapshot_partition_disk_usage_percent"`
 }
 
 func (j *SnapshotJob) getHttpAddToZip(node Node, endpoints map[string]string, folder string, zipWriter *zip.Writer, summaryReport *bytes.Buffer, config *Config) error {
@@ -142,6 +145,11 @@ func (j *SnapshotJob) getStatus(config *Config) snapshotReportStatus {
 
 		SnapshotBaseDir:       config.FlagSnapshotDir,
 		SnapshotJobTimeoutMin: config.FlagSnapshotJobTimeoutMinutes,
+		SnapshotJobGetSingleUrlTimeoutMinutes: config.FlagSnapshotJobGetSingleUrlTimeoutMinutes,
+		SnapshotUnitsLogsSinceHours: config.FlagSnapshotUnitsLogsSinceHours,
+		CommandExecTimeoutSec: config.FlagCommandExecTimeoutSec,
+
+
 		DiskUsedPercent:       used,
 	}
 }

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -1,0 +1,650 @@
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/shirou/gopsutil/disk"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"io/ioutil"
+)
+
+func getHttpAddToZip(node Node, endpoints map[string]string, folder string, zipWriter *zip.Writer, summaryReport *bytes.Buffer) error {
+	for fileName, httpEndpoint := range endpoints {
+		full_url := "http://"+node.Ip+httpEndpoint
+		log.Debugf("GET %s", full_url)
+		client := new(http.Client)
+		request, err := http.NewRequest("GET", full_url, nil)
+		if err != nil {
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not create request for url: %s", full_url), node, err.Error(), summaryReport)
+			continue
+		}
+		request.Header.Add("Accept-Encoding", "gzip")
+		resp, err := client.Do(request)
+		if err != nil {
+			log.Errorf("Could not fetch url: %s", full_url)
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not fetch url: %s", full_url), node, err.Error(), summaryReport)
+			continue
+		}
+		if resp.Header.Get("Content-Encoding") == "gzip" {
+			fileName += ".gz"
+		}
+
+		// put all logs in a `ip_role` folder
+		zipFile, err := zipWriter.Create(filepath.Join(node.Ip+"_"+node.Role, fileName))
+		if err != nil {
+			log.Errorf("Could not add %s to a zip archive", fileName)
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not add a file %s to a zip", fileName), node, err.Error(), summaryReport)
+			continue
+		}
+		io.Copy(zipFile, resp.Body)
+		resp.Body.Close()
+	}
+	return nil
+}
+
+func getFileAddToZip(node Node, files []FileProvider, folder string, zipWriter *zip.Writer, summaryReport *bytes.Buffer) error {
+	for _, f := range files {
+		file, err := os.Open(f.Location)
+		if err != nil {
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not add a file %s to a zip", f.Location), node, err.Error(), summaryReport)
+			continue
+		}
+		zipFile, err := zipWriter.Create(f.Location)
+		if err != nil {
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not add a file %s to a zip", f.Location), node, err.Error(), summaryReport)
+			continue
+		}
+		io.Copy(zipFile, file)
+	}
+
+	return nil
+}
+
+func getCmdAddToZip(node Node, commands []CommandProvider, folder string, zipWriter *zip.Writer, summaryReport *bytes.Buffer) error {
+	for _, command := range commands {
+		cmd := exec.Command(command.Command[0])
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not add a command output of %s to a zip", command), node, err.Error(), summaryReport)
+			continue
+		}
+		if err := cmd.Start(); err != nil {
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not add a command output of %s to a zip", command), node, err.Error(), summaryReport)
+			continue
+		}
+		zipFile, err := zipWriter.Create(strings.Join(command.Command, "_")+".output")
+		if err != nil {
+			log.Error(err)
+			updateSummaryReport(fmt.Sprintf("could not add a command output of %s to a zip", command), node, err.Error(), summaryReport)
+			continue
+		}
+		io.Copy(zipFile, stdout)
+	}
+	return nil
+}
+
+// snapshotJob
+type SnapshotJob struct {
+	sync.Mutex
+	cancelChan    chan bool
+
+	Running          bool          `json:"is_running"`
+	Status           string        `json:"status"`
+	Errors           []string      `json:"errors"`
+	LastSnapshotPath string        `json:"last_snapshot_dir"`
+	JobStarted       time.Time     `json:"job_started"`
+	JobEnded         time.Time     `json:"job_ended"`
+	JobDuration      time.Duration `json:"job_duration"`
+}
+
+type snapshotReportResponse struct {
+	Version int      `json:"version"`
+	Status  string   `json:"status"`
+	Errors  []string `json:"errors"`
+}
+
+type snapshotReportStatus struct {
+	// job related fields
+	Running          bool     `json:"is_running"`
+	Status           string   `json:"status"`
+	Errors           []string `json:"errors"`
+	LastSnapshotPath string   `json:"last_snapshot_dir"`
+	JobStarted       string   `json:"job_started"`
+	JobEnded         string   `json:"job_ended"`
+	JobDuration      string   `json:"job_duration"`
+
+	// config related fields
+	SnapshotBaseDir       string `json:"snapshot_dir"`
+	SnapshotJobTimeoutMin int    `json:"job_timeout_min"`
+
+	// metrics related
+	DiskUsedPercent float64 `json:"snapshot_partition_disk_usage_percent"`
+}
+
+func (j *SnapshotJob) getStatusAll(config *Config, puller Puller) (map[string]snapshotReportStatus, error) {
+	statuses := make(map[string]snapshotReportStatus)
+
+	masterNodes, err := puller.LookupMaster()
+	if err != nil {
+		return statuses, err
+	}
+
+	for _, master := range masterNodes {
+		var status snapshotReportStatus
+		url := fmt.Sprintf("http://%s:%d%s/report/snapshot/status", master.Ip, config.FlagPort, BaseRoute)
+		body, statusCode, err := puller.GetHttp(url)
+		if err = json.Unmarshal(body, &status); err != nil {
+			log.Errorf("GET %s failed, status code: %d", url, statusCode)
+			log.Error(err)
+			continue
+		}
+		statuses[master.Ip] = status
+	}
+	return statuses, nil
+}
+
+func (j *SnapshotJob) getStatus(config *Config) snapshotReportStatus {
+	// use a temp var `used`, since disk.Usage panics if partition does not exist.
+	var used float64
+	usageStat, err := disk.Usage(config.FlagSnapshotDir)
+	if err == nil {
+		used = usageStat.UsedPercent
+	} else {
+		log.Errorf("Could not get a disk usage: %s", config.FlagSnapshotDir)
+	}
+	return snapshotReportStatus{
+		Running:          j.Running,
+		Status:           j.Status,
+		Errors:           j.Errors,
+		LastSnapshotPath: j.LastSnapshotPath,
+		JobStarted:       j.JobStarted.String(),
+		JobEnded:         j.JobEnded.String(),
+		JobDuration:      j.JobDuration.String(),
+
+		SnapshotBaseDir:       config.FlagSnapshotDir,
+		SnapshotJobTimeoutMin: config.FlagSnapshotTimeoutMinutes,
+		DiskUsedPercent:       used,
+	}
+}
+
+func (j *SnapshotJob) start() {
+	j.Running = true
+}
+
+func (j *SnapshotJob) stop() {
+	j.Running = false
+}
+
+func (j *SnapshotJob) isSnapshotAvailable(snapshotName string, config *Config, puller Puller) (string, string, bool, error) {
+	snapshots, err := listAllSnapshots(config, puller)
+	if err != nil {
+		return "", "", false, err
+	}
+	log.Infof("Trying to find a snapshot %s on remote hosts", snapshotName)
+	for host, remoteSnapshots := range snapshots {
+		for _, remoteSnapshot := range remoteSnapshots {
+			if snapshotName == path.Base(remoteSnapshot) {
+				log.Infof("Snapshot %s found on a host: %s", snapshotName, host)
+				return host, remoteSnapshot, true, nil
+			}
+		}
+	}
+	return "", "", false, nil
+}
+
+//
+func (j *SnapshotJob) DeleteSnapshot(snapshotName string, config *Config) error {
+	if !strings.HasPrefix(snapshotName, "snapshot-") || !strings.HasSuffix(snapshotName, ".zip") {
+		return errors.New("format allowed  snapshot-*.zip")
+	}
+	snapshotPath := path.Join(config.FlagSnapshotDir, snapshotName)
+	log.Debugf("Trying remove snapshot: %s", snapshotPath)
+	_, err := os.Stat(snapshotPath)
+	if err != nil {
+		return err
+	}
+	if err = os.Remove(snapshotPath); err != nil {
+		return err
+	}
+	log.Infof("%s deleted", snapshotPath)
+	return nil
+}
+
+func (j *SnapshotJob) run(req snapshotCreateRequest, config *Config, puller Puller, dcosHealth HealthReporter) error {
+	if dcosHealth.GetNodeRole() == "agent" {
+		return errors.New("Running snapshot job on agent node is not implemented.")
+	}
+
+	if j.Running {
+		return errors.New("Job is already running")
+	}
+	_, err := os.Stat(config.FlagSnapshotDir)
+	if os.IsNotExist(err) {
+		log.Infof("snapshot dir: %s not found, attempting to create one", config.FlagSnapshotDir)
+		if err := os.Mkdir(config.FlagSnapshotDir, os.ModePerm); err != nil {
+			errMsg := fmt.Sprintf("Could not create snapshot directory: %s", config.FlagSnapshotDir)
+			j.Errors = append(j.Errors, errMsg)
+			j.Status = "Job failed"
+			return errors.New(errMsg)
+		}
+	}
+
+	t := time.Now()
+	j.LastSnapshotPath = fmt.Sprintf("%s/snapshot-%d-%02d-%02dT%02d:%02d:%02d-%d.zip", config.FlagSnapshotDir, t.Year(),
+		t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond())
+	j.Status = "Snapshot job started, archive will be available: " + j.LastSnapshotPath
+
+	// first discover all nodes in a cluster, then try to find requested nodes.
+	masterNodes, err := puller.LookupMaster()
+	if err != nil {
+		return err
+	}
+	agentNodes, err := puller.GetAgentsFromMaster()
+	if err != nil {
+		return err
+	}
+	foundNodes, err := findRequestedNodes(masterNodes, agentNodes, req.Nodes)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Found requested nodes: %s", foundNodes)
+
+	j.cancelChan = make(chan bool)
+	go j.runBackgroundReport(foundNodes, config, puller)
+	return nil
+}
+
+func updateSummaryReport(preflix string, node Node, error string, r *bytes.Buffer) {
+	r.WriteString(fmt.Sprintf("%s [%s] %s %s %s\n", time.Now().String(), preflix, node.Ip, node.Role, error))
+}
+
+func (j *SnapshotJob) runBackgroundReport(nodes []Node, config *Config, puller Puller) {
+	log.Info("Started background job")
+
+	// log a start time
+	j.JobStarted = time.Now()
+
+	// log end time
+	defer func(j *SnapshotJob) {
+		j.JobEnded = time.Now()
+		j.JobDuration = time.Since(j.JobStarted)
+		log.Info("Job finished")
+	}(j)
+
+	// lets start a goroutine which will timeout background report job after a certain time.
+	jobIsDone := make(chan bool)
+	go func(jobIsDone chan bool, j *SnapshotJob) {
+		select {
+		case <-jobIsDone:
+			return
+		case <-time.After(time.Minute * time.Duration(config.FlagSnapshotTimeoutMinutes)):
+			j.Status = "Job failed"
+			errMsg := fmt.Sprintf("snapshot job timedout after: %s", time.Since(j.JobStarted))
+			j.Errors = append(j.Errors, errMsg)
+			log.Error(errMsg)
+			j.cancelChan <- true
+			return
+		}
+	}(jobIsDone, j)
+
+	// makesure we always cancel a timeout gorutine when the report is finished.
+	defer func(jobIsDone chan bool) {
+		jobIsDone <- true
+	}(jobIsDone)
+
+	// Update job running field.
+	j.start()
+	defer j.stop()
+
+	// create a zip file
+	zipfile, err := os.Create(j.LastSnapshotPath)
+	if err != nil {
+		j.Status = "Job failed"
+		errMsg := fmt.Sprintf("Coult not create zip file: %s", j.LastSnapshotPath)
+		j.Errors = append(j.Errors, errMsg)
+		log.Error(errMsg)
+		return
+	}
+	defer zipfile.Close()
+
+	zipWriter := zip.NewWriter(zipfile)
+	defer zipWriter.Close()
+
+	// place a summaryErrorsReport.txt in a zip archive which should provide info what failed during the logs collection.
+	summaryErrorsReport := new(bytes.Buffer)
+	defer func(zipWriter *zip.Writer, summaryReport *bytes.Buffer) {
+		zipFile, err := zipWriter.Create("summaryErrorsReport.txt")
+		if err != nil {
+			j.Status = "Could not append a summaryErrorsReport.txt to a zip file, node"
+			log.Error(j.Status)
+			log.Error(err)
+			j.Errors = append(j.Errors, err.Error())
+			return
+		}
+		io.Copy(zipFile, summaryReport)
+	}(zipWriter, summaryErrorsReport)
+
+	// lock out reportJob staructure
+	j.Lock()
+	defer j.Unlock()
+
+	for _, node := range nodes {
+		url := fmt.Sprintf("http://%s:%d%s/logs", node.Ip, config.FlagPort, BaseRoute)
+		select {
+		case _, ok := <-j.cancelChan:
+			if ok {
+				j.Status = "Job has been canceled"
+				j.Errors = append(j.Errors, j.Status)
+				log.Debug(j.Status)
+				os.Remove(zipfile.Name())
+				j.LastSnapshotPath = ""
+				return
+			} else {
+				errMsg := "cancelChan is closed!"
+				j.Errors = append(j.Errors, errMsg)
+				return
+			}
+		default:
+			j.Status = fmt.Sprintf("Collecting from a node: %s, url: %s", node.Ip, url)
+			log.Debug(j.Status)
+		}
+
+		endpoints := make(map[string]string)
+		body, statusCode, err := puller.GetHttp(url)
+		if err != nil {
+			errMsg := fmt.Sprintf("could not get a list of logs, url: %s, status code %d", url, statusCode)
+			j.Errors = append(j.Errors, errMsg)
+			log.Error(err)
+			updateSummaryReport(errMsg, node, err.Error(), summaryErrorsReport)
+			continue
+		}
+		if err = json.Unmarshal(body, &endpoints); err != nil {
+			errMsg := "could not unmarshal a list of logs, url: " + url
+			j.Errors = append(j.Errors, errMsg)
+			log.Error(err)
+			updateSummaryReport(errMsg, node, err.Error(), summaryErrorsReport)
+			continue
+		}
+
+		// add http endpoints
+		err = getHttpAddToZip(node, endpoints, j.LastSnapshotPath, zipWriter, summaryErrorsReport)
+		if err != nil {
+			errMsg := "could not add logs for a node, url: " + url
+			j.Errors = append(j.Errors, errMsg)
+			log.Error(err)
+			updateSummaryReport(errMsg, node, err.Error(), summaryErrorsReport)
+		}
+	}
+	if len(j.Errors) == 0 {
+		j.Status = "Snapshot job sucessfully finished"
+	}
+}
+
+func findRequestedNodes(masterNodes []Node, agentNodes []Node, requestedNodes []string) (matchedNodes []Node, err error) {
+	clusterNodes := append(masterNodes, agentNodes...)
+	for _, requestedNode := range requestedNodes {
+		if requestedNode == "all" {
+			return clusterNodes, nil
+		}
+		if requestedNode == "masters" {
+			matchedNodes = append(matchedNodes, masterNodes...)
+		}
+		if requestedNode == "agents" {
+			matchedNodes = append(matchedNodes, agentNodes...)
+		}
+		// try to find nodes by ip / mesos id
+		for _, clusterNode := range clusterNodes {
+			if requestedNode == clusterNode.Ip || requestedNode == clusterNode.MesosId || requestedNode == clusterNode.Host {
+				matchedNodes = append(matchedNodes, clusterNode)
+			}
+		}
+	}
+	if len(matchedNodes) > 0 {
+		return matchedNodes, nil
+	}
+	return matchedNodes, errors.New(fmt.Sprintf("Requested nodes: %s not found", requestedNodes))
+}
+
+func (j *SnapshotJob) cancel(dcosHealth HealthReporter) error {
+	if dcosHealth.GetNodeRole() == "agent" {
+		return errors.New("Canceling snapshot job on agent node is not implemented.")
+	}
+
+	if !j.Running {
+		return errors.New("Job is not running")
+	}
+	log.Debug("Cancelling job")
+	j.cancelChan <- true
+	return nil
+}
+
+func dispatchLogs(provider string, entity string, config *Config, healthReport HealthReporter) (r io.ReadCloser, err error) {
+	intProviders, err := loadInternalProviders(config, healthReport)
+	if err != nil {
+		log.Error(err)
+	}
+	extProviders, err := loadExternalProviders(config, healthReport)
+	if err != nil {
+		log.Error(err)
+	}
+	if provider == "units" {
+		return readJournalOutput(entity, config.FlagSnapshotUnitsLogsSinceHours)
+	}
+	if provider == "files" {
+		for _, fileProvider := range append(intProviders.LocalFiles, extProviders.LocalFiles...) {
+			if filepath.Base(fileProvider.Location) == entity {
+				return readFile(fileProvider.Location)
+			}
+		}
+		return r, errors.New("Not found "+entity)
+	}
+	if provider == "cmds" {
+		for _, cmdProvider := range append(intProviders.LocalCommands, extProviders.LocalCommands...) {
+			if len(cmdProvider.Command) > 0 {
+				if entity == filepath.Base(cmdProvider.Command[0]) {
+					return runCmd(cmdProvider.Command)
+				}
+			}
+		}
+		return r, errors.New("Not found "+entity)
+	}
+	return r, errors.New("Unknown provider "+provider)
+}
+
+func runCmd(command []string) (r io.ReadCloser, err error) {
+	args := []string{}
+	if len(command) > 1 {
+		args = command[1:len(command)]
+	}
+	log.Infof("Run: %s", command)
+	cmd := exec.Command(command[0], args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return r, err
+	}
+	if err := cmd.Start(); err != nil {
+		return r, err
+	}
+	return stdout, nil
+}
+
+func readFile(fileLocation string) (r io.ReadCloser, err error) {
+	file, err := os.Open(fileLocation)
+	if err != nil {
+		return r, err
+	}
+	return file, nil
+}
+
+func readJournalOutput(unit string, since string) (r io.ReadCloser, err error) {
+	if !strings.HasPrefix(unit, "dcos-") {
+		return r, errors.New("Unit should start with dcos-, got: "+unit)
+	}
+	if strings.ContainsAny(unit, " ;") {
+		return r, errors.New("Unit cannot contain ; or spaces")
+	}
+	command := []string{"journalctl", "--no-pager", "-u", unit, "--since", since+" hours ago"}
+	return runCmd(command)
+}
+
+type LogProviders struct {
+	HTTPEndpoints []HttpProvider
+	LocalFiles    []FileProvider
+	LocalCommands []CommandProvider
+}
+
+type HttpProvider struct {
+	Port     int
+	Uri      string
+	FileName string
+	Role     string
+}
+
+type FileProvider struct {
+	Location string
+	Role     string
+}
+
+type CommandProvider struct {
+	Command []string
+	Role     string
+}
+
+// get a list of all available endpoints
+func getLogsEndpointList(config *Config, dcosHealth HealthReporter) (endpoints map[string]string, err error) {
+	internalProviders, err := loadInternalProviders(config, dcosHealth)
+	if err != nil {
+		log.Error(err)
+	}
+	externalProviders, err := loadExternalProviders(config, dcosHealth)
+	if err != nil {
+		log.Error(err)
+	}
+
+	endpoints = make(map[string]string)
+	// Load HTTP endpoints
+	for _, endpoint := range append(internalProviders.HTTPEndpoints, externalProviders.HTTPEndpoints...) {
+		// if role is set and does not equal current role, skip.
+		if endpoint.Role != "" && endpoint.Role != dcosHealth.GetNodeRole() {
+			continue
+		}
+		endpoints[endpoint.FileName] = fmt.Sprintf(":%d%s", endpoint.Port, endpoint.Uri)
+	}
+
+	// Load file endpoints
+	for _, file := range append(internalProviders.LocalFiles, externalProviders.LocalFiles...) {
+		// if role is set and does not equal current role, skip.
+		if file.Role != "" && file.Role != dcosHealth.GetNodeRole() {
+			continue
+		}
+		endpoints[file.Location] = fmt.Sprintf(":%d%s/logs/files/%s", config.FlagPort, BaseRoute, filepath.Base(file.Location))
+	}
+
+	// Load command endpoints
+	for _, c := range append(internalProviders.LocalCommands, externalProviders.LocalCommands...) {
+		// if role is set and does not equal current role, skip.
+		if c.Role != "" && c.Role != dcosHealth.GetNodeRole() {
+			continue
+		}
+		if len(c.Command) > 0 {
+			endpoints[filepath.Base(c.Command[0])+".output"] = fmt.Sprintf(":%d%s/logs/cmds/%s", config.FlagPort, BaseRoute, filepath.Base(c.Command[0]))
+		}
+	}
+	return endpoints, nil
+}
+
+func loadExternalProviders(config *Config, dcosHealth HealthReporter) (LogProviders, error) {
+	var externalProviders LogProviders
+	endpointsConfig, err := ioutil.ReadFile(config.FlagSnapshotEndpointsConfigFile)
+	if err != nil {
+		return externalProviders, err
+	}
+	if err = json.Unmarshal(endpointsConfig, &externalProviders); err != nil {
+		return externalProviders, err
+	}
+	return externalProviders, nil
+}
+
+func loadInternalProviders(config *Config, dcosHealth HealthReporter) (internalConfigProviders LogProviders, err error) {
+	units, err := dcosHealth.GetUnitNames()
+	if err != nil {
+		return
+	}
+
+	// load default HTTP
+	var httpEndpoints []HttpProvider
+	for _, unit := range append(units, config.SystemdUnits...) {
+		httpEndpoints = append(httpEndpoints, HttpProvider{
+			Port:     config.FlagPort,
+			Uri:      fmt.Sprintf("%s/logs/units/%s", BaseRoute, unit),
+			FileName: unit + ".log",
+		})
+	}
+	httpEndpoints = append(httpEndpoints, HttpProvider{
+		Port: 1050,
+		Uri: BaseRoute,
+		FileName: "3dt-health.log",
+	})
+
+	return LogProviders{
+		HTTPEndpoints: httpEndpoints,
+	}, nil
+}
+
+func listAllSnapshots(config *Config, puller Puller) (map[string][]string, error) {
+	collectedSnapshots := make(map[string][]string)
+	masterNodes, err := puller.LookupMaster()
+	if err != nil {
+		return collectedSnapshots, err
+	}
+	for _, master := range masterNodes {
+		var snapshotUrls []string
+		url := fmt.Sprintf("http://%s:%d%s/report/snapshot/list", master.Ip, config.FlagPort, BaseRoute)
+		body, _, err := puller.GetHttp(url)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		if err = json.Unmarshal(body, &snapshotUrls); err != nil {
+			log.Error(err)
+			continue
+		}
+		collectedSnapshots[fmt.Sprintf("%s:%d", master.Ip, config.FlagPort)] = snapshotUrls
+	}
+	return collectedSnapshots, nil
+}
+
+func (j *SnapshotJob) findLocalSnapshot(config *Config) (snapshots []string, err error) {
+	matches, err := filepath.Glob(config.FlagSnapshotDir + "/snapshot-*.zip")
+	for _, snapshot := range matches {
+		// skip a snapshot zip file if the job is running
+		if snapshot == j.LastSnapshotPath && j.Running {
+			log.Infof("Skipped listing %s, the job is running", snapshot)
+			continue
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	if err != nil {
+		return snapshots, err
+	}
+	return snapshots, nil
+}

--- a/api/snapshot_test.go
+++ b/api/snapshot_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	assertPackage "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+	"bytes"
+	"archive/zip"
+)
+
+type FakeSnapshotUtils struct {}
+
+func (j *FakeSnapshotUtils) getHttpAddToZip(node Node, report map[string]string, folder string, zipWriter *zip.Writer, summaryReport *bytes.Buffer) error {
+	return nil
+}
+
+type SnapshotTestSuit struct {
+	suite.Suite
+	assert *assertPackage.Assertions
+	dt     Dt
+}
+
+func (suit *SnapshotTestSuit) SetupTest() {
+	suit.assert = assertPackage.New(suit.T())
+	config, _ := LoadDefaultConfig([]string{"3dt", "-snapshot-dir", "/snapshots"})
+	suit.dt = Dt{
+		Cfg: &config,
+		DtHealth: &FakeHealthReport{},
+		DtPuller: &FakePuller{},
+		DtSnapshotJob: &SnapshotJob{},
+	}
+}
+
+func (suit *SnapshotTestSuit) TearDownTest() {
+	GlobalMonitoringResponse.UpdateMonitoringResponse(MonitoringResponse{})
+}
+
+func (s *SnapshotTestSuit) TestFindRequestedNodes() {
+	masterNodes := []Node{
+		Node{
+			Ip: "10.10.0.1",
+		},
+		Node{
+			Host: "my-host.com",
+		},
+		Node{
+			MesosId: "12345-12345",
+		},
+	}
+	agentNodes := []Node{
+		Node{
+			Ip: "127.0.0.1",
+		},
+	}
+	// should return masters + agents
+	requestedNodes := []string{"all"}
+	nodes, err := findRequestedNodes(masterNodes, agentNodes, requestedNodes)
+	s.assert.Nil(err)
+	s.assert.Equal(nodes, append(masterNodes, agentNodes...))
+
+	// should return only masters
+	requestedNodes = []string{"masters"}
+	nodes, err = findRequestedNodes(masterNodes, agentNodes, requestedNodes)
+	s.assert.Nil(err)
+	s.assert.Equal(nodes, masterNodes)
+
+	// should return only agents
+	requestedNodes = []string{"agents"}
+	nodes, err = findRequestedNodes(masterNodes, agentNodes, requestedNodes)
+	s.assert.Nil(err)
+	s.assert.Equal(nodes, agentNodes)
+
+	// should return host with ip
+	requestedNodes = []string{"10.10.0.1"}
+	nodes, err = findRequestedNodes(masterNodes, agentNodes, requestedNodes)
+	s.assert.Nil(err)
+	s.assert.Equal(nodes, []Node{masterNodes[0]})
+
+	// should return host with hostname
+	requestedNodes = []string{"my-host.com"}
+	nodes, err = findRequestedNodes(masterNodes, agentNodes, requestedNodes)
+	s.assert.Nil(err)
+	s.assert.Equal(nodes, []Node{masterNodes[1]})
+
+	// should return host with mesos-id
+	requestedNodes = []string{"12345-12345"}
+	nodes, err = findRequestedNodes(masterNodes, agentNodes, requestedNodes)
+	s.assert.Nil(err)
+	s.assert.Equal(nodes, []Node{masterNodes[2]})
+
+	// should return agents and node with ip
+	requestedNodes = []string{"agents", "10.10.0.1"}
+	nodes, err = findRequestedNodes(masterNodes, agentNodes, requestedNodes)
+	s.assert.Nil(err)
+	s.assert.Equal(nodes, append(agentNodes, masterNodes[0]))
+}
+
+func (s *SnapshotTestSuit) TestGetStatus() {
+	status := s.dt.DtSnapshotJob.getStatus(s.dt.Cfg)
+	s.assert.Equal(status.SnapshotBaseDir, "/snapshots")
+}
+
+func (s *SnapshotTestSuit) TestGetAllStatus() {
+	status, err := s.dt.DtSnapshotJob.getStatusAll(s.dt.Cfg, s.dt.DtPuller)
+	s.assert.Nil(err)
+	s.assert.Contains(status, "127.0.0.1")
+	s.assert.Equal(status["127.0.0.1"], snapshotReportStatus{
+		Running: true,
+		Status: "MyStatus",
+		LastSnapshotPath: "/path/to/snapshot",
+		JobStarted: "0001-01-01 00:00:00 +0000 UTC",
+		JobEnded: "0001-01-01 00:00:00 +0000 UTC",
+		JobDuration: "2s",
+		SnapshotBaseDir: "/home/core/1",
+		SnapshotJobTimeoutMin: 720,
+		DiskUsedPercent: 28.0,
+	})
+}
+
+func (s *SnapshotTestSuit) TestisSnapshotAvailable() {
+	// should find
+	host, remoteSnapshot, ok, err := s.dt.DtSnapshotJob.isSnapshotAvailable("snapshot-2016-05-13T22:11:36.zip", s.dt.Cfg, s.dt.DtPuller)
+	s.assert.True(ok)
+	s.assert.Equal(host, "127.0.0.1:1050")
+	s.assert.Equal(remoteSnapshot, "/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip")
+	s.assert.Nil(err)
+
+	// should not find
+	host, remoteSnapshot, ok, err = s.dt.DtSnapshotJob.isSnapshotAvailable("snapshot-123.zip", s.dt.Cfg, s.dt.DtPuller)
+	s.assert.False(ok)
+	s.assert.Empty(host)
+	s.assert.Empty(remoteSnapshot)
+	s.assert.Nil(err)
+}
+
+func TestSnapshotTestSuit(t *testing.T) {
+	suite.Run(t, new(SnapshotTestSuit))
+}

--- a/api/snapshot_test.go
+++ b/api/snapshot_test.go
@@ -114,6 +114,9 @@ func (s *SnapshotTestSuit) TestGetAllStatus() {
 		SnapshotBaseDir: "/home/core/1",
 		SnapshotJobTimeoutMin: 720,
 		DiskUsedPercent: 28.0,
+		SnapshotUnitsLogsSinceHours: "24",
+		SnapshotJobGetSingleUrlTimeoutMinutes: 5,
+		CommandExecTimeoutSec: 10,
 	})
 }
 
@@ -121,7 +124,7 @@ func (s *SnapshotTestSuit) TestisSnapshotAvailable() {
 	// should find
 	host, remoteSnapshot, ok, err := s.dt.DtSnapshotJob.isSnapshotAvailable("snapshot-2016-05-13T22:11:36.zip", s.dt.Cfg, s.dt.DtPuller)
 	s.assert.True(ok)
-	s.assert.Equal(host, "127.0.0.1:1050")
+	s.assert.Equal(host, "127.0.0.1")
 	s.assert.Equal(remoteSnapshot, "/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip")
 	s.assert.Nil(err)
 

--- a/api/structures.go
+++ b/api/structures.go
@@ -133,6 +133,7 @@ type DcosHealth struct {
 type Dt struct {
 	DtPuller        Puller
 	DtHealth        HealthReporter
+	HTTPRequest     HTTPRequester
 	DtSnapshotJob   *SnapshotJob
 	Cfg             *Config
 }

--- a/endpoints_config.json
+++ b/endpoints_config.json
@@ -1,0 +1,243 @@
+{
+    "HTTPEndpoints": [
+        {
+            "Port": 5050,
+            "Uri": "/__processes__",
+            "FileName": "master-___processes__.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/flags",
+            "FileName": "master-_master_flags.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/frameworks",
+            "FileName": "master-_master_frameworks.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/maintenance/schedule",
+            "FileName": "master-_master_maintenance_schedule.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/maintenance/status",
+            "FileName": "master-_master_maintenance_status.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/roles",
+            "FileName": "master-_master_roles.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/slaves",
+            "FileName": "master-_master_slaves.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/state",
+            "FileName": "master-_master_state.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/state-summary",
+            "FileName": "master-_master_state-summary.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/master/tasks",
+            "FileName": "master-_master_tasks.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/metrics/snapshot",
+            "FileName": "master-_metrics_snapshot.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/registrar(1)/registry",
+            "FileName": "master-_registrar(1)_registry.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/system/stats.json",
+            "FileName": "master-_system_stats.json.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5050,
+            "Uri": "/version",
+            "FileName": "master-_version.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/metrics",
+            "FileName": "marathon-_metrics.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/apps",
+            "FileName": "marathon-_v2_apps.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/deployments",
+            "FileName": "marathon-_v2_deployments.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/eventSubscriptions",
+            "FileName": "marathon-_v2_eventSubscriptions.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/groups",
+            "FileName": "marathon-_v2_groups.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/info",
+            "FileName": "marathon-_v2_info.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/leader",
+            "FileName": "marathon-_v2_leader.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/queue",
+            "FileName": "marathon-_v2_queue.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8080,
+            "Uri": "/v2/tasks",
+            "FileName": "marathon-_v2_tasks.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8181,
+            "Uri": "/exhibitor/v1/cluster/list",
+            "FileName": "exhibitor-_exhibitor_v1_cluster_list.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8181,
+            "Uri": "/exhibitor/v1/cluster/log",
+            "FileName": "exhibitor-_exhibitor_v1_cluster_log.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8181,
+            "Uri": "/exhibitor/v1/cluster/state",
+            "FileName": "exhibitor-_exhibitor_v1_cluster_state.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8181,
+            "Uri": "/exhibitor/v1/cluster/status",
+            "FileName": "exhibitor-_exhibitor_v1_cluster_status.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8181,
+            "Uri": "/exhibitor/v1/config/get-state",
+            "FileName": "exhibitor-_exhibitor_v1_config_get-state.log",
+            "Role": "master"
+        },
+        {
+            "Port": 5051,
+            "Uri": "/__processes__",
+            "FileName": "agent-___processes__.log",
+            "Role": "agent"
+        },
+        {
+            "Port": 5051,
+            "Uri": "/metrics/snapshot",
+            "FileName": "agent-_metrics_snapshot.log",
+            "Role": "agent"
+        },
+        {
+            "Port": 5051,
+            "Uri": "/slave/flags",
+            "FileName": "agent-_slave_flags.log",
+            "Role": "agent"
+        },
+        {
+            "Port": 5051,
+            "Uri": "/slave/state",
+            "FileName": "agent-_slave_state.log",
+            "Role": "agent"
+        },
+        {
+            "Port": 5051,
+            "Uri": "/system/stats.json",
+            "FileName": "agent-_system_stats.json.log",
+            "Role": "agent"
+        },
+        {
+            "Port": 8123,
+            "Uri": "/v1/config",
+            "FileName": "mesosdns-_v1_config.log",
+            "Role": "master"
+        },
+        {
+            "Port": 8123,
+            "Uri": "/v1/version",
+            "FileName": "mesosdns-_v1_version.log",
+            "Role": "master"
+        },
+        {
+            "Port": 15055,
+            "Uri": "/history/last",
+            "FileName": "history-_hisotry_last.log",
+            "Role": "master"
+        },
+        {
+            "Port": 15055,
+            "Uri": "/history/minute",
+            "FileName": "history-_hisotry_minute.log",
+            "Role": "master"
+        },
+        {
+            "Port": 15055,
+            "Uri": "/history/hour",
+            "FileName": "history-_hisotry_hour.log",
+            "Role": "master"
+        }
+    ],
+    "LocalFiles": [
+        {
+            "Location": "/opt/mesosphere/active.buildinfo.full.json"
+        }
+    ],
+    "LocalCommands": [
+        {
+            "Command": ["dmesg"]
+        }
+    ]
+}
+


### PR DESCRIPTION
3dt will be used to collect system logs across the DC/OS cluster.

- [x] add system metrics to a health report (DCOS-6544)
- [x] add /logs endpoint to collect all system logs (DCOS-6545)
- [x] collect metrics using DC/OS HTTP endpoints (DCOS-6546)
- [x] reverse proxy snapshot download
- [x] update /report endpoint to support cluster snapshot feature (DCOS-6547)
- [ ] update unit tests
- [ ] update integration tests