### PR TITLE
refactor 3dt

### DIFF
--- a/3dt.go
+++ b/3dt.go
@@ -48,7 +48,6 @@ func main() {
 	// Inject dependencies used for running 3dt.
 	dt := api.Dt{
 		Cfg: &config,
-		DtPuller: &api.DcosPuller{},
 		DtDCOSTools: &api.DCOSTools{},
 	}
 

--- a/api/config.go
+++ b/api/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version of 3dt code.
-const Version string = "0.0.14"
+const Version string = "0.1.0"
 
 // Revision injected by LDFLAGS a git commit reference.
 var Revision string
@@ -20,7 +20,6 @@ type Config struct {
 	Revision                string
 	MesosIPDiscoveryCommand string
 	DCOSVersion             string
-	DCOSTools               DCOSHelper
 	SystemdUnits            []string
 
 	FlagPull                       bool
@@ -70,7 +69,6 @@ func LoadDefaultConfig(args []string) (config Config, err error) {
 		log.Warning("Environment variable DCOS_VERSION is not set")
 	}
 	config.DCOSVersion = os.Getenv("DCOS_VERSION")
-	config.DCOSTools = &DCOSTools{}
 	config.SystemdUnits = []string{"dcos-setup.service", "dcos-link-env.service", "dcos-download.service"}
 
 	flagSet := flag.NewFlagSet("3dt", flag.ContinueOnError)

--- a/api/health.go
+++ b/api/health.go
@@ -145,7 +145,7 @@ func GetUnitsProperties(dt Dt) (healthReport UnitsHealthResponseJSONStruct, err 
 	}
 	var allUnitsProperties []healthResponseValues
 	// open dbus connection
-	if err = dt.DtDCOSTools.InitializeDbusConnection(); err != nil {
+	if err = dt.DtDCOSTools.InitializeDBUSConnection(); err != nil {
 		return healthReport, err
 	}
 	log.Debug("Opened dbus connection")
@@ -167,7 +167,7 @@ func GetUnitsProperties(dt Dt) (healthReport UnitsHealthResponseJSONStruct, err 
 		allUnitsProperties = append(allUnitsProperties, normalizeProperty(unit, currentProperty, dt.DtDCOSTools))
 	}
 	// after we finished querying systemd units, close dbus connection
-	if err = dt.DtDCOSTools.CloseDbusConnection(); err != nil {
+	if err = dt.DtDCOSTools.CloseDBUSConnection(); err != nil {
 		// we should probably return here, since we cannot guarantee that all units have been queried.
 		return healthReport, err
 	}
@@ -184,7 +184,7 @@ func GetUnitsProperties(dt Dt) (healthReport UnitsHealthResponseJSONStruct, err 
 	healthReport.Role, err = dt.DtDCOSTools.GetNodeRole()
 	logError(err)
 
-	healthReport.MesosID, err = dt.DtDCOSTools.GetMesosNodeID(dt.DtDCOSTools.GetNodeRole)
+	healthReport.MesosID, err = dt.DtDCOSTools.GetMesosNodeID()
 	logError(err)
 	healthReport.TdtVersion = dt.Cfg.Version
 

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -5,31 +5,13 @@ import (
 	"time"
 )
 
-// Puller interface
-type Puller interface {
-	// function to get a list of masters uses dns lookup of master.mesos, append to *[]Host
-	LookupMaster() ([]Node, error)
-
-	// function gets a list of agents from master.mesos:5050/slaves, append to *[]Host
-	GetAgentsFromMaster() ([]Node, error)
-
-	// functions make a GET request to a remote node, return an array of response, response status and error
-	GetUnitsPropertiesViaHTTP(string) ([]byte, int, error)
-
-	// function to wait between pulls
-	WaitBetweenPulls(int)
-
-	// Get timestamp
-	GetTimestamp() time.Time
-}
-
 // DCOSHelper DC/OS specific tools interface.
 type DCOSHelper interface {
 	// open dbus connection
-	InitializeDbusConnection() error
+	InitializeDBUSConnection() error
 
 	// close dbus connection
-	CloseDbusConnection() error
+	CloseDBUSConnection() error
 
 	// function to get Connection.GetUnitProperties(pname)
 	// returns a maps of properties https://github.com/coreos/go-systemd/blob/master/dbus/methods.go#L176
@@ -52,7 +34,7 @@ type DCOSHelper interface {
 	GetJournalOutput(string) (string, error)
 
 	// Get mesos node id, first argument is a function to determine a role.
-	GetMesosNodeID(func() (string, error)) (string, error)
+	GetMesosNodeID() (string, error)
 
 	// Get makes HTTP GET request, return read arrays of bytes
 	Get(string, time.Duration) ([]byte, int, error)
@@ -63,6 +45,21 @@ type DCOSHelper interface {
 	// MakeRequest makes an HTTP request with predefined http.Request object.
 	// Caller is responsible for calling http.Response.Body().Close()
 	HTTPRequest(*http.Request, time.Duration) (*http.Response, error)
+
+	// LookupMaster will lookup a masters in DC/OS cluster.
+	// Initial lookup will be done by making HTTP GET request to exhibitor.If GET request fails, the next lookup
+	// will failover to history service for one minute, it this fails or no nodes found, masters will be looked up
+	// in history service for last hour.
+	GetMasterNodes() ([]Node, error)
+	//
+	//// GetAgentsFromMaster will lookup agents in DC/OS cluster.
+	GetAgentNodes() ([]Node, error)
+
+	// function to wait between pulls
+	WaitBetweenPulls(int)
+
+	// Get timestamp
+	GetTimestamp() time.Time
 }
 
 // with the nodeFinder interface we can chain finding methods

--- a/api/pull.go
+++ b/api/pull.go
@@ -456,17 +456,17 @@ func (mr *monitoringResponse) GetNodeUnitByNodeIDUnitID(nodeIP string, unitID st
 }
 
 // StartPullWithInterval will start to pull a DC/OS cluster health status
-func StartPullWithInterval(config Config, pi Puller, ready chan struct{}) {
+func StartPullWithInterval(dt Dt, ready chan struct{}) {
 	select {
 	case <-ready:
-		log.Infof("Start pulling with interval %d", config.FlagPullInterval)
+		log.Infof("Start pulling with interval %d", dt.Cfg.FlagPullInterval)
 	case <-time.After(time.Second * 10):
 		log.Error("Not ready to pull from localhost after 10 seconds")
 	}
 
 	// Start infinite loop
 	for {
-		runPull(config.FlagPullInterval, config.FlagPort, pi)
+		runPull(dt.Cfg.FlagPullInterval, dt.Cfg.FlagPort, dt.DtPuller)
 	}
 }
 

--- a/api/router.go
+++ b/api/router.go
@@ -40,13 +40,13 @@ func headerMiddleware(next http.Handler, headers []header) http.Handler {
 	})
 }
 
-func getRoutes(config *Config) []routeHandler {
+func getRoutes(dt Dt) []routeHandler {
 	return []routeHandler{
 		{
 			// /system/health/v1
 			url: BaseRoute,
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				unitsHealthStatus(w, r, config)
+				unitsHealthStatus(w, r, dt.Cfg)
 			},
 		},
 		{
@@ -116,8 +116,8 @@ func wrapHandler(handler http.Handler, route routeHandler) http.Handler {
 	return handlerWithHeader
 }
 
-func loadRoutes(router *mux.Router, config *Config) *mux.Router {
-	for _, route := range getRoutes(config) {
+func loadRoutes(router *mux.Router, dt Dt) *mux.Router {
+	for _, route := range getRoutes(dt) {
 		if len(route.methods) == 0 {
 			route.methods = []string{"GET"}
 		}
@@ -128,7 +128,7 @@ func loadRoutes(router *mux.Router, config *Config) *mux.Router {
 }
 
 // NewRouter returns a new *mux.Router with loaded routes.
-func NewRouter(config *Config) *mux.Router {
+func NewRouter(dt Dt) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	return loadRoutes(router, config)
+	return loadRoutes(router, dt)
 }

--- a/api/structures.go
+++ b/api/structures.go
@@ -122,6 +122,5 @@ type exhibitorNodeResponse struct {
 // the one used for testing.
 type Dt struct {
 	Cfg         *Config
-	DtPuller    Puller
 	DtDCOSTools DCOSHelper
 }

--- a/api/structures.go
+++ b/api/structures.go
@@ -117,3 +117,11 @@ type exhibitorNodeResponse struct {
 	Hostname    string
 	IsLeader    bool
 }
+
+// Dt is a struct of dependencies used in 3dt code. There are 2 implementations, the one runs on a real system and
+// the one used for testing.
+type Dt struct {
+	Cfg         *Config
+	DtPuller    Puller
+	DtDCOSTools DCOSHelper
+}


### PR DESCRIPTION
- refactor 3dt code to inject all dependencies beforehand. This will be used
  to pass a snapshot job via instance of `dt` to handlers.