### PR TITLE
add snapshot size in API response

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -207,10 +207,19 @@ func listAvailableLocalSnapshotFilesHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var snapshots []string
+	var snapshots []snapshot
 	for _, file := range matches {
 		baseFile := filepath.Base(file)
-		snapshots = append(snapshots, fmt.Sprintf("%s/report/snapshot/serve/%s", BaseRoute, baseFile))
+		fileInfo, err := os.Stat(file)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+
+		snapshots = append(snapshots, snapshot{
+			File: fmt.Sprintf("%s/report/snapshot/serve/%s", BaseRoute, baseFile),
+			Size: fileInfo.Size(),
+		})
 	}
 	if err := json.NewEncoder(w).Encode(snapshots); err != nil {
 		log.Error("Failed to encode responses to json")

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -540,14 +540,14 @@ func (j *SnapshotJob) stop() {
 }
 
 // get a list of all snapshots across the cluster.
-func listAllSnapshots(config *Config, DCOSTools DCOSHelper) (map[string][]string, error) {
-	collectedSnapshots := make(map[string][]string)
+func listAllSnapshots(config *Config, DCOSTools DCOSHelper) (map[string][]snapshot, error) {
+	collectedSnapshots := make(map[string][]snapshot)
 	masterNodes, err := DCOSTools.GetMasterNodes()
 	if err != nil {
 		return collectedSnapshots, err
 	}
 	for _, master := range masterNodes {
-		var snapshotUrls []string
+		var snapshotUrls []snapshot
 		url := fmt.Sprintf("http://%s:%d%s/report/snapshot/list", master.IP, config.FlagMasterPort, BaseRoute)
 		body, _, err := DCOSTools.Get(url, time.Duration(time.Second*3))
 		if err != nil {
@@ -572,11 +572,11 @@ func (j *SnapshotJob) isSnapshotAvailable(snapshotName string, config *Config, D
 	log.Infof("Trying to find a snapshot %s on remote hosts", snapshotName)
 	for host, remoteSnapshots := range snapshots {
 		for _, remoteSnapshot := range remoteSnapshots {
-			if snapshotName == path.Base(remoteSnapshot) {
+			if snapshotName == path.Base(remoteSnapshot.File) {
 				log.Infof("Snapshot %s found on a host: %s", snapshotName, host)
 				hostPort := strings.Split(host, ":")
 				if len(hostPort) > 0 {
-					return hostPort[0], remoteSnapshot, true, nil
+					return hostPort[0], remoteSnapshot.File, true, nil
 				}
 				return "", "", false, errors.New("Node must be ip:port. Got " + host)
 			}

--- a/api/snapshot_test.go
+++ b/api/snapshot_test.go
@@ -173,7 +173,7 @@ func (s *SnapshotTestSuit) TestGetAllStatus() {
 
 func (s *SnapshotTestSuit) TestisSnapshotAvailable() {
 	url := fmt.Sprintf("http://127.0.0.1:1050%s/report/snapshot/list", BaseRoute)
-	mockedResponse := `["/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip"]`
+	mockedResponse := `[{"file_name": "/system/health/v1/report/snapshot/serve/snapshot-2016-05-13T22:11:36.zip", "file_size": 123}]`
 
 	st := &fakeDCOSTools{}
 	st.makeMockedResponse(url, []byte(mockedResponse), http.StatusOK, nil)

--- a/api/structures.go
+++ b/api/structures.go
@@ -127,3 +127,8 @@ type Dt struct {
 	DtDCOSTools DCOSHelper
 	DtSnapshotJob *SnapshotJob
 }
+
+type snapshot struct {
+	File string `json:"file_name"`
+	Size int64  `json:"file_size"`
+}


### PR DESCRIPTION
a CLI will display size of a snapshot and warn user if the file
is too big.