### PR TITLE
add flap detect

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// Version of 3dt code.
-	Version = "0.2.2"
+	Version = "0.2.3"
 
 	// APIVer is an API version.
 	APIVer = 1

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -74,9 +74,11 @@ func (st *fakeDCOSTools) GetUnitProperties(pname string) (map[string]interface{}
 	if pname == "unit_to_fail" {
 		return result, errors.New("unit_to_fail occured")
 	}
+	result["Id"] = pname
 	result["LoadState"] = "loaded"
 	result["ActiveState"] = "active"
 	result["Description"] = "PrettyName: My fake description"
+	result["SubState"] = "running"
 	return result, nil
 }
 
@@ -673,7 +675,7 @@ func (s *HandlersTestSuit) TestStartUpdateHealthReportFunc() {
 	s.assert.Equal(hr.DcosVersion, "")
 	s.assert.Equal(hr.Role, "master")
 	s.assert.Equal(hr.MesosID, "node-id-123")
-	s.assert.Equal(hr.TdtVersion, "0.2.2")
+	s.assert.Equal(hr.TdtVersion, "0.2.3")
 }
 
 func TestHandlersTestSuit(t *testing.T) {

--- a/api/health.go
+++ b/api/health.go
@@ -167,7 +167,12 @@ func GetUnitsProperties(dt Dt) (healthReport UnitsHealthResponseJSONStruct, err 
 			log.Errorf("Could not get properties for unit: %s", unit)
 			continue
 		}
-		allUnitsProperties = append(allUnitsProperties, normalizeProperty(unit, currentProperty, dt.DtDCOSTools))
+		normalizedProperty, err := normalizeProperty(currentProperty, dt)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		allUnitsProperties = append(allUnitsProperties, normalizedProperty)
 	}
 	// after we finished querying systemd units, close dbus connection
 	if err = dt.DtDCOSTools.CloseDBUSConnection(); err != nil {

--- a/api/structures.go
+++ b/api/structures.go
@@ -132,3 +132,17 @@ type bundle struct {
 	File string `json:"file_name"`
 	Size int64  `json:"file_size"`
 }
+
+// UnitPropertiesResponse is a structure to unmarshal dbus.GetunitProperties response
+type UnitPropertiesResponse struct {
+	ID                              string `json:"Id"`
+	LoadState                       string
+	ActiveState                     string
+	SubState                        string
+	Description                     string
+
+	InactiveExitTimestampMonotonic  uint64
+	ActiveEnterTimestampMonotonic   uint64
+	ActiveExitTimestampMonotonic    uint64
+	InactiveEnterTimestampMonotonic uint64
+}


### PR DESCRIPTION
fix unit check
A systemd unit has several state fields.
1. `LoadState` tells where the configuration file of this unit has been loaded.
   We consider a unit unhealthy if LoadState != "loaded"

2. `ActiveState` tells whether the unit is `active` or not. Possbile states:
   active, reloading, inactive, failed, activating, deactivating. We consider
   `active`, `inactive` and `activating*` to be healthy active states.

3. `SubState` a more detailed state description. Should be `running` for a
   healthy state. And should be `dead` for one shot.

*This change adds slightly more checks for `activating` state listed in 2.
When the service is in `activating` state it may indicate that the service is
unable to start (become active). The reason for failure might be a failing
ExecStartPre script. To make sure we catch that we are using the following
logic.

A unit is considered to be unhealthy if:
 - `ActiveState` is `activating` and `SubState` is `auto-restart` and
   (`ActiveEnterTimestampMonotonic` is 0 or \
      `InactiveEnterTimestampMonotonic`  > `ActiveEnterTimestampMonotonic`)
   that means that a unit either can't start at all for the first time or
   unit was able to start before but now it can't

for ref: https://www.freedesktop.org/wiki/Software/systemd/dbus/