### PR TITLE
add custom nodes not found error

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// Version of 3dt code.
-	Version = "0.2.10"
+	Version = "0.2.11"
 
 	// APIVer is an API version.
 	APIVer = 1

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -672,7 +672,7 @@ func (s *HandlersTestSuit) TestStartUpdateHealthReportFunc() {
 	s.assert.Equal(hr.DcosVersion, "")
 	s.assert.Equal(hr.Role, "master")
 	s.assert.Equal(hr.MesosID, "node-id-123")
-	s.assert.Equal(hr.TdtVersion, "0.2.10")
+	s.assert.Equal(hr.TdtVersion, "0.2.11")
 }
 
 func TestHandlersTestSuit(t *testing.T) {

--- a/api/pull.go
+++ b/api/pull.go
@@ -82,6 +82,15 @@ func (f *findMastersInExhibitor) find() (nodes []Node, err error) {
 	return nodes, err
 }
 
+// NodesNotFoundError is a custom error called when nodes are not found.
+type NodesNotFoundError struct {
+	msg  string
+}
+
+func (n NodesNotFoundError) Error() string {
+	return n.msg
+}
+
 // find agents in history service
 type findAgentsInHistoryService struct {
 	pastTime string
@@ -125,7 +134,9 @@ func (f *findAgentsInHistoryService) getMesosAgents() (nodes []Node, err error) 
 
 	}
 	if len(nodeCount) == 0 {
-		return nodes, errors.New("Agent nodes were not found in history service for the past hour")
+		return nodes, NodesNotFoundError{
+			msg: fmt.Sprintf("Agent nodes were not found in history service for the past %s", f.pastTime),
+		}
 	}
 
 	for ip := range nodeCount {

--- a/api/selftest.go
+++ b/api/selftest.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	log "github.com/Sirupsen/logrus"
 )
 
 func findAgentsInHistoryServiceSelfTest(pastTime string) error {
@@ -54,7 +55,14 @@ func runSelfTest() map[string]*selfTestResponse {
 		if err == nil {
 			result[selfTestName].Success = true
 		} else {
-			result[selfTestName].ErrorMessage = err.Error()
+			// check for NodesNotFoundError. Do not fail if this happens. It just means history service
+			// was did not dump anything yet.
+			if serr, ok := err.(NodesNotFoundError); ok {
+				log.Debugf("Non critical error recevied: %s", serr)
+				result[selfTestName].Success = true
+			} else {
+				result[selfTestName].ErrorMessage = err.Error()
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
while 3dt nodes discovery logic relies on error if nodes not found,
we should not hard fail in self test. This causes flaky integration tests.