### PR TITLE
disable keep-alive connections

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// Version of 3dt code.
-	Version = "0.2.13"
+	Version = "0.2.14"
 
 	// APIVer is an API version.
 	APIVer = 1

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -672,7 +672,7 @@ func (s *HandlersTestSuit) TestStartUpdateHealthReportFunc() {
 	s.assert.Equal(hr.DcosVersion, "")
 	s.assert.Equal(hr.Role, "master")
 	s.assert.Equal(hr.MesosID, "node-id-123")
-	s.assert.Equal(hr.TdtVersion, "0.2.13")
+	s.assert.Equal(hr.TdtVersion, "0.2.14")
 }
 
 func TestHandlersTestSuit(t *testing.T) {


### PR DESCRIPTION
3dt integration test has been flkay lately. In vagrant environment
we are running out of open files, causing 3dt not to accept new connections.