### PR TITLE
Enable Mergebot in 3DT repo.

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -1,0 +1,5 @@
+{
+  "ship-it": true,
+  "integrate-it": true,
+  "test-it": true
+}

--- a/owners.json
+++ b/owners.json
@@ -1,0 +1,3 @@
+{
+  "darkonie" : null
+}


### PR DESCRIPTION
This config change is to enable @mesosphere-mergebot 

1. A webhook needs to be added.
2. Use of integrate-it and test-it will require write permission for @mesosphere-mergebot to this repo.

Instructions are documented here: https://mesosphere.atlassian.net/wiki/display/DCOS/Mesosphere+Mergebot