### PR TITLE
Updated mergebot commands

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -1,5 +1,5 @@
 {
   "ship-it": true,
-  "integrate-it": true,
-  "test-it": true
+  "integrate": true,
+  "test": true
 }


### PR DESCRIPTION
`-it` is no longer required for the `test` and `integrate`. DCOS-11489