### PR TITLE
fix systemd unit logs entry

### DIFF
--- a/vendor/github.com/dcos/dcos-log/dcos-log/journal/reader/config.go
+++ b/vendor/github.com/dcos/dcos-log/dcos-log/journal/reader/config.go
@@ -52,6 +52,23 @@ func OptionMatch(m []JournalEntryMatch) Option {
 	}
 }
 
+// OptionMatchOR is a functional option that filters entries and applies logical OR to user
+// arguments []JournalEntryMatch.
+func OptionMatchOR(m []JournalEntryMatch) Option {
+	return func(r *Reader) error {
+		if r.Journal == nil {
+			return ErrUninitializedReader
+		}
+
+		for _, match := range m {
+			r.Journal.AddMatch(match.String())
+			r.Journal.AddDisjunction()
+		}
+
+		return nil
+	}
+}
+
 // OptionSeekCursor is a functional option that seeks a cursor in the journal.
 func OptionSeekCursor(c string) Option {
 	return func(r *Reader) error {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -56,10 +56,10 @@
 			"revisionTime": "2016-12-20T17:47:03Z"
 		},
 		{
-			"checksumSHA1": "eiWAM3OruvF6CF66PEGdDIcR8ko=",
+			"checksumSHA1": "JhJJQCCXRHfkWYtlYjp6p2WE5Hs=",
 			"path": "github.com/dcos/dcos-log/dcos-log/journal/reader",
-			"revision": "858754d83ec9aa68c90bf79ae9e79bef428f6388",
-			"revisionTime": "2017-01-07T03:03:01Z"
+			"revision": "d64779821404c1e1fb8ded49041bd43de8beb3ba",
+			"revisionTime": "2017-04-20T00:15:40Z"
 		},
 		{
 			"checksumSHA1": "7oJyGPn6FhDZeJy9wuWqWSQ5XFM=",


### PR DESCRIPTION
it turns out systemd marks the log unit entries differently.
UNIT: <systemd.service> and _SYSTEMD_UNIT: <systemd.service>
we need to get the logs for UNIT or _SYSTEMD_UNIT

https://jira.mesosphere.com/browse/DCOS_OSS-987