### PR TITLE
Backport https://github.com/dcos/dcos/pull/1219 to 1.8.9

### DIFF
--- a/endpoints_config.json
+++ b/endpoints_config.json
@@ -194,6 +194,23 @@
     "LocalFiles": [
         {
             "Location": "/opt/mesosphere/active.buildinfo.full.json"
+        },
+        {
+            "Location": "/opt/mesosphere/etc/dcos-version.json"
+        },
+        {
+            "Location": "/opt/mesosphere/etc/expanded.config.json"
+        },
+        {
+            "Location": "/opt/mesosphere/etc/user.config.yaml"
+        },
+        {
+            "Location": "/var/lib/dcos/exhibitor/zookeeper/snapshot/myid",
+            "Role": ["master"]
+        },
+        {
+            "Location": "/var/lib/dcos/exhibitor/conf/zoo.cfg",
+            "Role": ["master"]
         }
     ],
     "LocalCommands": [


### PR DESCRIPTION
Trying to backport https://github.com/dcos/dcos/pull/1219 to 1.8.9. So I have created this branch to be able to reference it in https://github.com/dcos/dcos