### PR TITLE
check runner must run checks on agent and agent_public nodes

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dcos/dcos-go/dcos"
 	"github.com/pkg/errors"
 )
 
@@ -18,6 +19,13 @@ const (
 
 // NewRunner returns an initialized instance of *Runner.
 func NewRunner(role string) *Runner {
+	// according to design doc, runner config must treat roles `agent` and `agent_public`
+	// as a single `agent` role. If a user create a config and sets role `agent`, we expect to run this
+	// check on both agent and agent_public nodes.
+	// https://jira.mesosphere.com/browse/DCOS_OSS-1242
+	if role == dcos.RoleAgentPublic {
+		role = dcos.RoleAgent
+	}
 	return &Runner{
 		role: role,
 	}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -10,3 +10,20 @@ func TestConfigLoadConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestNewRunner(t *testing.T) {
+	r := NewRunner("master")
+	if r.role != "master" {
+		t.Fatalf("expecting role master. Got %s", r.role)
+	}
+
+	r = NewRunner("agent")
+	if r.role != "agent" {
+		t.Fatalf("expecting role agent. Got %s", r.role)
+	}
+
+	r = NewRunner("agent_public")
+	if r.role != "agent" {
+		t.Fatalf("expecting role agent. Got %s", r.role)
+	}
+}


### PR DESCRIPTION
3dt has notion of agents and public agents. Checks runner should always
treat agent as an alias to agent and agent_public roles.
https://jira.mesosphere.com/browse/DCOS_OSS-1242