### PR TITLE
fix cluster check invocation

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -175,7 +175,14 @@ func (r *Runner) validate() error {
 
 // Cluster executes cluster runner defined in config.
 func (r *Runner) Cluster(ctx context.Context, list bool, selectiveChecks ...string) (*CombinedResponse, error) {
-	return r.run(ctx, r.ClusterChecks, list, selectiveChecks)
+	return r.run(ctx, r.ClusterChecks, list, r.clusterCheckNames(), selectiveChecks...)
+}
+
+func (r *Runner) clusterCheckNames() (clusterChecks []string) {
+	for checkName := range r.ClusterChecks {
+		clusterChecks = append(clusterChecks, checkName)
+	}
+	return
 }
 
 // PreStart executes the runner defined in config node_checks->prestart.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,7 +1,11 @@
 package runner
 
 import (
+	"context"
+	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestConfigLoadConfig(t *testing.T) {
@@ -26,4 +30,77 @@ func TestNewRunner(t *testing.T) {
 	if r.role != "agent" {
 		t.Fatalf("expecting role agent. Got %s", r.role)
 	}
+}
+
+func TestRun(t *testing.T) {
+	r := NewRunner("master")
+	cfg := `
+	{
+	  "cluster_checks": {
+	    "test_check": {
+	      "cmd": ["./fixture/combined.sh"],
+	      "timeout": "1s"
+	    }
+	  },
+	  "node_checks": {
+	    "checks": {
+	      "check1": {
+	        "cmd": ["./fixture/combined.sh"],
+		  "timeout": "1s"
+	        },
+	      "check2": {
+		"cmd": ["./fixture/combined.sh"],
+		"timeout": "1s"
+	      }
+	    },
+	    "prestart": ["check1"],
+	    "poststart": ["check2"]
+	   }
+	}
+	`
+	r.Load(strings.NewReader(cfg))
+	out, err := r.Cluster(context.TODO(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutput := "STDOUT\nSTDERR\n"
+
+	if err := validateCheck(out, "test_check", expectedOutput); err != nil {
+		t.Fatal(err)
+	}
+
+	prestart, err := r.PreStart(context.TODO(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateCheck(prestart, "check1", expectedOutput); err != nil {
+		t.Fatal(err)
+	}
+
+	poststart, err := r.PostStart(context.TODO(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateCheck(poststart, "check2", expectedOutput); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateCheck(cr *CombinedResponse, name, output string) error {
+	if cr.Status() != 0 {
+		return errors.Errorf("expect exit code 0. Got %d", cr.Status())
+	}
+
+	check, ok := cr.checks[name]
+	if !ok {
+		return errors.Errorf("expect check %s", name)
+	}
+
+	if check.output != output {
+		return errors.Errorf("expect %s. Got %s", output, check.output)
+	}
+	return nil
 }


### PR DESCRIPTION
during the refactor the cluster check invocation was broken due to lack of unittests.
Fix the bug and add unittests to cover Cluster, Prestart and Poststart